### PR TITLE
FIX::CoreReasonCode: Added parameterless Initializer

### DIFF
--- a/BaseLib.Core/BaseLib.Core.csproj
+++ b/BaseLib.Core/BaseLib.Core.csproj
@@ -5,7 +5,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<PackageId>BaseLib.Core</PackageId>
-		<Version>2.1.0.1</Version>
+		<Version>2.1.0.2</Version>
 		<Authors>Mauricio David Obando</Authors>
 		<Company>Mauricio David Obando</Company>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/BaseLib.Core/Models/CoreReasonCode.cs
+++ b/BaseLib.Core/Models/CoreReasonCode.cs
@@ -8,6 +8,9 @@ namespace BaseLib.Core.Models
         public static CoreReasonCode Null { get { return CoreServiceReasonCode.Undefined; } }
         public static CoreReasonCode Succeeded { get { return CoreServiceReasonCode.Succeeded; } }
         public static CoreReasonCode Failed { get { return CoreServiceReasonCode.Failed; } }
+        public CoreReasonCode(): this(CoreServiceReasonCode.Undefined)
+        {
+        }
 
         public static implicit operator CoreReasonCode(Enum enumValue)
             => new CoreReasonCode(Convert.ToInt32(enumValue), enumValue.GetDescription());


### PR DESCRIPTION
a parameterless initializer is added to be able to deserialize XML streams into types that inherits CoreResponseBase 