### PR TITLE
docs: Comprehensive documentation overhaul across all modules

### DIFF
--- a/BaseLib.Core.AmazonCloud/BaseLib.Core.AmazonCloud.csproj
+++ b/BaseLib.Core.AmazonCloud/BaseLib.Core.AmazonCloud.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/mauriciodavid70/BaseLib</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>    
     <PackageReference Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.0" />

--- a/BaseLib.Core.AmazonCloud/readme.md
+++ b/BaseLib.Core.AmazonCloud/readme.md
@@ -2,13 +2,13 @@
 
 ## Overview
 
-Contains concrete implementations of the interfaces from **BaseLib.Core** for Amazon AWS 
+Contains concrete implementations of the interfaces from **BaseLib.Core** for Amazon AWS.
 
 ## Services
 
 ### Event support
 
-**SnsCoreStatusEventSink** is an implementation of the **ICoreStatusEventSink** interface, providing support for event-driven choreography between services. 
+**SnsCoreStatusEventSink** is an implementation of the **ICoreStatusEventSink** interface, providing support for event-driven choreography between services.
 
 In the example below, once the CheckoutService completes its process, it writes an event to the EventSink. The event sink then publishes this event to an SNS Topic. This topic has two Lambda subscribers which, upon receiving the event, execute the **CreateOrderService** and **CreateInvoiceServices**, respectively.
 
@@ -21,8 +21,163 @@ flowchart LR;
 
 ```
 
+#### Configuration
+
+`SnsCoreStatusEventSink` accepts the SNS topic name (not ARN). It resolves the topic ARN on first use and caches it.
+
+```csharp
+// Dependency injection setup
+services.AddSingleton<IAmazonSimpleNotificationService>(sp =>
+    new AmazonSimpleNotificationServiceClient());
+
+services.AddSingleton<ICoreStatusEventSink>(sp =>
+    new SnsCoreStatusEventSink(
+        sp.GetRequiredService<IAmazonSimpleNotificationService>(),
+        topicName: "my-service-events"          // plain name, not ARN
+        // For FIFO topics: "my-service-events.fifo"
+    ));
+```
+
+> **FIFO topics**: if the topic name ends with `.fifo`, `SnsCoreStatusEventSink` automatically sets `MessageGroupId` and `MessageDeduplicationId` on every published message.
+
+---
+
+### Fire-and-Forget Dispatch (SQS)
+
+**SqsCoreServiceFireOnly** implements `ICoreServiceFireOnly`, dispatching service invocations as SQS messages. It is required by `CoreLongRunningServiceBase` to fan out child service calls.
+
+- Uses an SQS **FIFO** queue for guaranteed ordering and exactly-once delivery.
+- Supports batch sends (`FireManyAsync`) with configurable batch size and concurrency.
+
+#### Configuration
+
+```csharp
+services.AddSingleton<IAmazonSQS>(sp => new AmazonSQSClient());
+
+services.AddSingleton<ICoreServiceFireOnly>(sp =>
+    new SqsCoreServiceFireOnly(
+        sp.GetRequiredService<IAmazonSQS>(),
+        queueName: "my-service-queue.fifo",     // must be a FIFO queue
+        maxConcurrency: 10,                      // max parallel batch sends (default: 10)
+        batchSize: 10                            // SQS messages per batch request (default: 10)
+    ));
+```
+
+---
+
 ### Secrets Vault
 
-the ***ICoreSecretsVault*** is the BaseLib.Core application abstraction of a vault that keeps safe sensitive information such as credentials and API keys to connect to other systems.
+**AmazonSecretsVault** implements `ICoreSecretsVault` on top of AWS Secrets Manager.
 
- The AmazonSecretsVault is the implementation on top of AWS Secret Manager.
+#### Configuration
+
+```csharp
+services.AddSingleton<IAmazonSecretsManager>(sp =>
+    new AmazonSecretsManagerClient());
+
+services.AddSingleton<ICoreSecretsVault>(sp =>
+    new AmazonSecretsVault(
+        sp.GetRequiredService<IAmazonSecretsManager>()));
+```
+
+#### Usage
+
+```csharp
+public class MyService : CoreServiceBase<MyRequest, MyResponse>
+{
+    private readonly ICoreSecretsVault _vault;
+
+    public MyService(ICoreSecretsVault vault) => _vault = vault;
+
+    protected override async Task<MyResponse> RunAsync()
+    {
+        var apiKey = await _vault.GetSecretValueAsync("prod/myapp/api-key");
+        // use apiKey ...
+    }
+}
+```
+
+> Secret names typically follow the pattern `<environment>/<app>/<key>` (e.g. `prod/checkout/stripe-key`), but any Secrets Manager secret name or ARN is accepted.
+
+---
+
+## Security — Envelope Encryption
+
+### KmsEncryptionKeyProvider
+
+Generates AES-256 data keys via AWS KMS `GenerateDataKey`. The plaintext key is used for encryption; the ciphertext blob (wrapped key) is stored alongside the encrypted data.
+
+```csharp
+services.AddSingleton<IAmazonKeyManagementService>(sp =>
+    new AmazonKeyManagementServiceClient());
+
+services.AddSingleton<IEncryptionKeyProvider>(sp =>
+    new KmsEncryptionKeyProvider(
+        sp.GetRequiredService<IAmazonKeyManagementService>(),
+        kmsKeyName: "alias/my-data-key"         // KMS key ID, alias, or ARN
+    ));
+```
+
+### S3CachedEncryptionProvider
+
+Wraps any `IEncryptionKeyProvider` and caches the wrapped key in S3. A new key is generated once per day; subsequent calls within the same day retrieve the cached wrapped key from S3 and unwrap it locally.
+
+```csharp
+services.AddSingleton<IEncryptionKeyProvider>(sp =>
+    new S3CachedEncryptionProvider(
+        innerProvider: sp.GetRequiredService<KmsEncryptionKeyProvider>(),
+        s3: sp.GetRequiredService<IAmazonS3>(),
+        bucketName: "my-encryption-keys-bucket",
+        folderName: "cache/keys"                 // default: "cache/keys"
+    ));
+```
+
+**Key file naming**: keys are stored as `{folderName}/wrapped_{unixTimestampOfToday}.key`.
+
+> Store only the *wrapped* (encrypted) key in S3, never the plaintext key. IAM policies on the S3 bucket and the KMS key should be the primary access controls.
+
+---
+
+## Mail — Amazon SES
+
+**AmazonEmailSender** implements `IEmailSender` using Amazon SES v2. Build the `MimeMessage` with `EmailMessageFactory` from `BaseLib.Core` and pass it to `SendAsync`.
+
+```csharp
+services.AddSingleton<IAmazonSimpleEmailServiceV2>(sp =>
+    new AmazonSimpleEmailServiceV2Client());
+
+services.AddSingleton<IEmailSender>(sp =>
+    new AmazonEmailSender(
+        sp.GetRequiredService<IAmazonSimpleEmailServiceV2>()));
+```
+
+---
+
+## IAM Permissions Summary
+
+| Component | Required AWS permissions |
+|---|---|
+| `SnsCoreStatusEventSink` | `sns:Publish` on the target topic |
+| `SqsCoreServiceFireOnly` | `sqs:SendMessage`, `sqs:GetQueueUrl` on the target queue |
+| `AmazonSecretsVault` | `secretsmanager:GetSecretValue` on the target secrets |
+| `KmsEncryptionKeyProvider` | `kms:GenerateDataKey`, `kms:Decrypt` on the target key |
+| `S3CachedEncryptionProvider` | `s3:GetObject`, `s3:PutObject` on the cache bucket |
+| `AmazonEmailSender` | `ses:SendEmail` for the sender identity |
+
+---
+
+## Environment Setup
+
+For local development, configure AWS credentials via the standard credential chain:
+
+```bash
+# Option 1 — AWS CLI profile
+aws configure --profile myapp
+
+# Option 2 — environment variables
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+When running in AWS (Lambda, ECS, EC2), attach an IAM role with the permissions listed above — no credential configuration is needed.

--- a/BaseLib.Core.MySql/BaseLib.Core.MySql.csproj
+++ b/BaseLib.Core.MySql/BaseLib.Core.MySql.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/mauriciodavid70/BaseLib</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseNuGetPackages)' != 'true'">

--- a/BaseLib.Core.MySql/readme.md
+++ b/BaseLib.Core.MySql/readme.md
@@ -2,17 +2,25 @@
 
 ## Overview
 
-Contains concrete implementations of the interfaces from **BaseLib.Core** for MySql
+Contains concrete implementations of the interfaces from **BaseLib.Core** for MySQL.
 
 ## Services
 
-`JournalEntryWriter` is the implementation of `IJournalEntryWriter` to store the events in a relational JOURNAL table.
-Check the source code for the dbinstall-v1.0.0.sql script to create the table
+### JournalEntryWriter
 
-> As a best practice, for security and performance reasons, store only the JournalEntry in the relational database. Request and Responses should be store in an object store in a secure manner.
+`JournalEntryWriter` implements `IJournalEntryWriter` to persist service execution records in a relational `JOURNAL` table.
+
+On each service run, two writes occur:
+1. **Started** — an `INSERT` when the service begins.
+2. **Finished** — an `UPDATE` when the service completes (falls back to `INSERT` if the started record is missing).
+
+> **Best practice**: Store only the `JournalEntry` (metadata) in the relational database. Request and response payloads should be stored in a secure object store (e.g. S3).
+
+#### JOURNAL table schema
+
+Run `dbinstall-v1.0.0.sql` (included in the source) to create the table:
 
 ```sql
-#JOURNAL TABLE
 CREATE TABLE IF NOT EXISTS JOURNAL (
   ID int NOT NULL AUTO_INCREMENT,
   SERVICE_NAME VARCHAR(255) DEFAULT NULL,
@@ -31,7 +39,120 @@ CREATE TABLE IF NOT EXISTS JOURNAL (
 )
 ```
 
+#### Configuration
 
-##Extensions
+```csharp
+// Register per-request (transient) since MySqlConnection is not thread-safe
+services.AddTransient<IJournalEntryWriter>(sp =>
+{
+    var connection = new MySqlConnection(connectionString);
+    connection.Open();
+    return new JournalEntryWriter(connection);
+});
+```
 
-`MySqlConnection::SetWaitTimeout()` allows to specify the session wait timeout
+---
+
+### LongRunningServiceManager
+
+`LongRunningServiceManager` implements `ICoreLongRunningServiceManager` using a MySQL `LONG_RUNNING_BATCH` table to track parent/child service relationships.
+
+It reacts to three lifecycle events:
+
+| Event | Action |
+|---|---|
+| `HandleParentSuspendedAsync` | Inserts a parent batch record; resumes immediately if all children already finished |
+| `HandleChildrenFinishedAsync` | Bulk-inserts child records and updates counters; resumes the parent when all children are done |
+| `HandleParentFinishedAsync` | Updates the parent batch record with the final status |
+
+#### LONG_RUNNING_BATCH table schema
+
+```sql
+CREATE TABLE IF NOT EXISTS LONG_RUNNING_BATCH (
+  ID int NOT NULL AUTO_INCREMENT,
+  OPERATION_ID VARCHAR(255) NOT NULL,
+  CORRELATION_ID VARCHAR(255) DEFAULT NULL,
+  SERVICE_NAME VARCHAR(500) DEFAULT NULL,
+  SERVICE_STATUS INT DEFAULT NULL,
+  STARTED_ON TIMESTAMP(6) DEFAULT NULL,
+  FINISHED_ON TIMESTAMP(6) DEFAULT NULL,
+  SUCCEEDED BOOLEAN DEFAULT NULL,
+  REASON_CODE INT DEFAULT NULL,
+  REASON VARCHAR(255) DEFAULT NULL,
+  CHILDREN_COUNT INT DEFAULT NULL,
+  COMPLETED_OK INT DEFAULT NULL,
+  COMPLETED_ERR INT DEFAULT NULL,
+  LAST_UPDATED TIMESTAMP(6) DEFAULT NULL,
+  PRIMARY KEY (ID),
+  UNIQUE KEY IX_OPERATION (OPERATION_ID),
+  KEY IX_CORRELATION (CORRELATION_ID)
+)
+```
+
+#### Configuration
+
+```csharp
+services.AddSingleton<ICoreLongRunningServiceManager>(sp =>
+    new LongRunningServiceManager(
+        connectionFactory: () =>
+        {
+            var conn = new MySqlConnection(connectionString);
+            conn.Open();
+            return conn;
+        },
+        invoker: sp.GetRequiredService<ICoreServiceFireOnly>()
+    ));
+```
+
+---
+
+## Extensions
+
+### `MySqlConnection` extensions
+
+| Method | Description |
+|---|---|
+| `SetWaitTimeout(int timeout)` | Sets the MySQL session `wait_timeout` in seconds. Useful in long-lived connection pools to prevent silent disconnects. |
+| `GetWaitTimeout()` | Returns the current session `wait_timeout` value. |
+
+```csharp
+using (var conn = new MySqlConnection(connectionString))
+{
+    conn.Open();
+    conn.SetWaitTimeout(3600); // keep connection alive for 1 hour
+}
+```
+
+### `MySqlException` extensions
+
+| Method | Returns | Description |
+|---|---|---|
+| `IsTransient()` | `bool` | `true` for transient errors (stream read failures, timeouts, deadlocks, connection failures) that are safe to retry. |
+| `IsDuplicate()` | `bool` | `true` for duplicate key violations (safe to swallow on upsert patterns). |
+
+```csharp
+catch (MySqlException ex) when (ex.IsTransient())
+{
+    // retry logic
+}
+```
+
+---
+
+## Troubleshooting
+
+### "Reading from the stream has failed" / connection drops
+
+The MySQL server closed the connection while it was idle in the pool. Use `SetWaitTimeout` to align the session timeout with your application's connection pool idle timeout, or configure keep-alive pings in the connection string:
+
+```
+Server=...;Connection Timeout=30;Default Command Timeout=60;Connection Reset=true;
+```
+
+### Duplicate key on JOURNAL insert
+
+`JournalEntryWriter` silently ignores duplicate-key exceptions on insert (`IsDuplicate()` returns `true`). This is expected when a `Started` event arrives after the `Finished` event due to out-of-order delivery.
+
+### "max_allowed_packet" errors on bulk child insert
+
+`LongRunningServiceManager` batches child records in groups of 128 rows. If you still hit packet-size limits, reduce the batch by lowering the constant or increase `max_allowed_packet` in your MySQL server config.

--- a/BaseLib.Core/BaseLib.Core.csproj
+++ b/BaseLib.Core/BaseLib.Core.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/mauriciodavid70/BaseLib</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Include="readme.md" Pack="true" PackagePath="\" />

--- a/BaseLib.Core/Mail/IEmailSender.cs
+++ b/BaseLib.Core/Mail/IEmailSender.cs
@@ -2,12 +2,25 @@ using BaseLib.Core.Models;
 using MimeKit;
 
 namespace BaseLib.Core.Mail;
+
+/// <summary>
+/// Sends email messages via an underlying mail transport.
+/// The AWS implementation delegates to Amazon SES via <c>AmazonEmailSender</c>.
+/// </summary>
 public interface IEmailSender
 {
+    /// <summary>
+    /// Sends the given <paramref name="message"/> using the underlying transport.
+    /// </summary>
+    /// <param name="message">The MIME message to send, constructed via <c>EmailMessageFactory</c>.</param>
+    /// <returns>An <see cref="EmailResponse"/> indicating whether the send succeeded.</returns>
     Task<EmailResponse> SendAsync(MimeMessage message);
 }
 
+/// <summary>
+/// Response returned by <see cref="IEmailSender.SendAsync"/>.
+/// Inherits <see cref="CoreResponseBase.Succeeded"/> and <see cref="CoreResponseBase.ReasonCode"/>.
+/// </summary>
 public class EmailResponse : CoreResponseBase
 {
-
 }

--- a/BaseLib.Core/Security/ICoreSecretsVault.cs
+++ b/BaseLib.Core/Security/ICoreSecretsVault.cs
@@ -1,7 +1,17 @@
 namespace BaseLib.Core.Security
 {
+    /// <summary>
+    /// Retrieves sensitive configuration values (credentials, API keys, connection strings)
+    /// from a secure vault. The AWS implementation delegates to AWS Secrets Manager
+    /// via <c>AmazonSecretsVault</c>.
+    /// </summary>
     public interface ICoreSecretsVault
     {
+        /// <summary>
+        /// Retrieves the plain-text value of the secret identified by <paramref name="secretName"/>.
+        /// </summary>
+        /// <param name="secretName">The name or ARN of the secret to retrieve.</param>
+        /// <returns>The secret's plain-text string value.</returns>
         Task<string> GetSecretValueAsync(string secretName);
     }
 }

--- a/BaseLib.Core/Security/IEncryptionKeyProvider.cs
+++ b/BaseLib.Core/Security/IEncryptionKeyProvider.cs
@@ -1,8 +1,26 @@
 namespace BaseLib.Core.Security
 {
+    /// <summary>
+    /// Generates and unwraps encryption keys for envelope encryption.
+    /// The AWS implementation uses KMS via <c>KmsEncryptionKeyProvider</c>.
+    /// For caching, wrap any provider with <c>S3CachedEncryptionProvider</c>.
+    /// </summary>
     public interface IEncryptionKeyProvider
     {
+        /// <summary>
+        /// Generates a new data encryption key and its KMS-wrapped (encrypted) counterpart.
+        /// </summary>
+        /// <returns>
+        /// A tuple containing the plaintext <c>key</c> (use for encrypting data) and
+        /// the <c>wrappedKey</c> (store alongside encrypted data; never store the plaintext key).
+        /// </returns>
         Task<(byte[] key, byte[] wrappedKey)> GetEncryptionKeyAsync();
+
+        /// <summary>
+        /// Decrypts a previously wrapped key back to its plaintext form.
+        /// </summary>
+        /// <param name="wrappedKey">The encrypted key bytes returned by <see cref="GetEncryptionKeyAsync"/>.</param>
+        /// <returns>The plaintext key bytes.</returns>
         Task<byte[]> UnwrapKeyAsync(byte[] wrappedKey);
     }
 }

--- a/BaseLib.Core/Serialization/ICoreSerializer.cs
+++ b/BaseLib.Core/Serialization/ICoreSerializer.cs
@@ -1,8 +1,23 @@
 namespace BaseLib.Core.Serialization
 {
+    /// <summary>
+    /// Abstracts JSON serialization so the transport layer (SQS, SNS, etc.) is decoupled
+    /// from a specific serializer implementation.
+    /// The default implementation is <see cref="CoreJsonSerializer"/>.
+    /// Use <c>CoreSecureJsonSerializer</c> when payloads contain fields annotated with
+    /// <c>[CoreSecret]</c> that must be encrypted at rest.
+    /// </summary>
     public interface ICoreSerializer
     {
+        /// <summary>Serializes <paramref name="value"/> to a JSON string.</summary>
+        /// <typeparam name="T">The type to serialize.</typeparam>
+        /// <param name="value">The object to serialize.</param>
         string Serialize<T>(T value);
+
+        /// <summary>Deserializes a JSON string to an instance of <typeparamref name="T"/>.</summary>
+        /// <typeparam name="T">The target type.</typeparam>
+        /// <param name="json">The JSON string to deserialize.</param>
+        /// <returns>The deserialized object, or <see langword="null"/> if the JSON is null or empty.</returns>
         T? Deserialize<T>(string json);
     }
 }

--- a/BaseLib.Core/Services/ICoreLongRunningService.cs
+++ b/BaseLib.Core/Services/ICoreLongRunningService.cs
@@ -2,14 +2,32 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
-    public interface ICoreLongRunningService 
+    /// <summary>
+    /// Non-generic marker interface for a long-running service that can be resumed after
+    /// its child operations complete. Enables type-erased resumption by message dispatchers.
+    /// </summary>
+    public interface ICoreLongRunningService
     {
+        /// <summary>
+        /// Restores persisted state and continues execution for the given <paramref name="operationId"/>.
+        /// </summary>
+        /// <param name="operationId">The operation identifier assigned when the service was first started.</param>
         Task<CoreResponseBase> ResumeAsync(string operationId);
     }
 
+    /// <summary>
+    /// Strongly-typed contract for a long-running service that suspends while child
+    /// operations run asynchronously and resumes when they complete.
+    /// Inherit from <see cref="CoreLongRunningServiceBase{TRequest,TResponse}"/> to implement.
+    /// </summary>
+    /// <typeparam name="TResponse">The response type returned when the service completes.</typeparam>
     public interface ICoreLongRunningService<TResponse> : ICoreLongRunningService
         where TResponse : CoreResponseBase, new()
     {
+        /// <summary>
+        /// Restores persisted state and continues execution, returning a strongly-typed response.
+        /// </summary>
+        /// <param name="operationId">The operation identifier assigned when the service was first started.</param>
         new Task<TResponse> ResumeAsync(string operationId);
     }
 }

--- a/BaseLib.Core/Services/ICoreLongRunningServiceManager.cs
+++ b/BaseLib.Core/Services/ICoreLongRunningServiceManager.cs
@@ -4,10 +4,33 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services;
 
+/// <summary>
+/// Coordinates the lifecycle of a long-running service by reacting to status events
+/// emitted by the parent and its children.
+/// Implement this interface in the infrastructure layer (e.g. an SQS event processor)
+/// to automatically resume suspended parents once all children have finished.
+/// </summary>
 public interface ICoreLongRunningServiceManager
-{   
+{
+    /// <summary>
+    /// Called when a long-running parent service has suspended, waiting for its children.
+    /// Implementations should persist enough context to resume the parent later.
+    /// </summary>
+    /// <param name="coreEvent">The status event emitted by the suspended parent service.</param>
     Task HandleParentSuspendedAsync(CoreStatusEvent coreEvent);
-    Task HandleParentFinishedAsync(CoreStatusEvent coreEvent);
-    Task HandleChildrenFinishedAsync(CoreStatusEvent[] coreEvent);
 
+    /// <summary>
+    /// Called when a long-running parent service has finished (either successfully or with an error).
+    /// Implementations should clean up any tracking state for this operation.
+    /// </summary>
+    /// <param name="coreEvent">The status event emitted by the finished parent service.</param>
+    Task HandleParentFinishedAsync(CoreStatusEvent coreEvent);
+
+    /// <summary>
+    /// Called when one or more child operations have finished.
+    /// If all expected children for a parent have now completed, implementations should
+    /// trigger <see cref="ICoreServiceFireOnly.ResumeAsync{TService}"/> for the parent.
+    /// </summary>
+    /// <param name="coreEvent">Array of status events emitted by the finished child services.</param>
+    Task HandleChildrenFinishedAsync(CoreStatusEvent[] coreEvent);
 }

--- a/BaseLib.Core/Services/ICoreServiceBase.cs
+++ b/BaseLib.Core/Services/ICoreServiceBase.cs
@@ -2,15 +2,44 @@
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Non-generic marker interface for a core service. Enables type-erased invocation when the
+    /// concrete request/response types are not known at compile time (e.g. message dispatchers).
+    /// </summary>
     public interface ICoreServiceBase
     {
+        /// <summary>
+        /// Executes the service with a base-typed request and returns a base-typed response.
+        /// </summary>
+        /// <param name="request">The request to process.</param>
+        /// <param name="correlationId">Optional correlation identifier used to group related operations.</param>
+        /// <param name="isLongRunningChild">
+        /// <see langword="true"/> when this invocation is a child spawned by a
+        /// <see cref="CoreLongRunningServiceBase{TRequest,TResponse}"/>; <see langword="false"/> otherwise.
+        /// </param>
         Task<CoreResponseBase> RunAsync(CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false);
     }
 
+    /// <summary>
+    /// Strongly-typed contract for a core service that processes a <typeparamref name="TRequest"/>
+    /// and returns a <typeparamref name="TResponse"/>.
+    /// Inherit from <see cref="CoreServiceBase{TRequest,TResponse}"/> to implement.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type, derived from <see cref="CoreRequestBase"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type, derived from <see cref="CoreResponseBase"/>.</typeparam>
     public interface ICoreServiceBase<TRequest, TResponse> : ICoreServiceBase
         where TRequest : CoreRequestBase
         where TResponse : CoreResponseBase, new()
     {
+        /// <summary>
+        /// Executes the service with the strongly-typed <paramref name="request"/>.
+        /// </summary>
+        /// <param name="request">The strongly-typed request to process.</param>
+        /// <param name="correlationId">Optional correlation identifier used to group related operations.</param>
+        /// <param name="isLongRunningChild">
+        /// <see langword="true"/> when this invocation is a child spawned by a
+        /// long-running service; <see langword="false"/> otherwise.
+        /// </param>
         Task<TResponse> RunAsync(TRequest request, string? correlationId = null, bool isLongRunningChild = false);
     }
 }

--- a/BaseLib.Core/Services/ICoreServiceFireOnly.cs
+++ b/BaseLib.Core/Services/ICoreServiceFireOnly.cs
@@ -2,17 +2,57 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Dispatches service invocations asynchronously without waiting for the result.
+    /// Used by <see cref="CoreLongRunningServiceBase{TRequest,TResponse}"/> to spawn
+    /// child service calls that run independently while the parent suspends.
+    /// </summary>
     public interface ICoreServiceFireOnly
-
     {
+        /// <summary>
+        /// Fires a strongly-typed service invocation without awaiting its result.
+        /// </summary>
+        /// <typeparam name="TService">The service type to invoke.</typeparam>
+        /// <param name="request">The request payload.</param>
+        /// <param name="correlationId">Optional correlation identifier to link related operations.</param>
+        /// <param name="isLongRunningChild"><see langword="true"/> when called from a long-running parent service.</param>
         Task FireAsync<TService>(CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false)
             where TService : ICoreServiceBase;
+
+        /// <summary>
+        /// Fires a service invocation by assembly-qualified type name without awaiting its result.
+        /// </summary>
+        /// <param name="typeName">Assembly-qualified type name of the service to invoke.</param>
+        /// <param name="request">The request payload.</param>
+        /// <param name="correlationId">Optional correlation identifier.</param>
+        /// <param name="isLongRunningChild"><see langword="true"/> when called from a long-running parent service.</param>
         Task FireAsync(string typeName, CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false);
+
+        /// <summary>
+        /// Fires multiple requests against the same service type in a single batch without awaiting results.
+        /// </summary>
+        /// <typeparam name="TService">The service type to invoke for each request.</typeparam>
+        /// <param name="requests">Collection of request payloads.</param>
+        /// <param name="correlationId">Optional correlation identifier shared by all requests in the batch.</param>
+        /// <param name="isLongRunningChild"><see langword="true"/> when called from a long-running parent service.</param>
         Task FireManyAsync<TService>(IEnumerable<CoreRequestBase> requests, string? correlationId = null, bool isLongRunningChild = false)
             where TService : ICoreServiceBase;
+
+        /// <summary>
+        /// Resumes a suspended long-running service by its <paramref name="operationId"/>.
+        /// </summary>
+        /// <typeparam name="TService">The long-running service type to resume.</typeparam>
+        /// <param name="operationId">The operation identifier assigned when the service was first started.</param>
+        /// <param name="correlationId">Optional correlation identifier.</param>
         Task ResumeAsync<TService>(string operationId, string? correlationId = null)
             where TService : ICoreLongRunningService;
-        Task ResumeAsync(string typeName, string operationId, string? correlationId = null);
 
+        /// <summary>
+        /// Resumes a suspended long-running service identified by assembly-qualified type name.
+        /// </summary>
+        /// <param name="typeName">Assembly-qualified type name of the long-running service.</param>
+        /// <param name="operationId">The operation identifier assigned when the service was first started.</param>
+        /// <param name="correlationId">Optional correlation identifier.</param>
+        Task ResumeAsync(string typeName, string operationId, string? correlationId = null);
     }
 }

--- a/BaseLib.Core/Services/ICoreServiceRunner.cs
+++ b/BaseLib.Core/Services/ICoreServiceRunner.cs
@@ -2,9 +2,27 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Resolves and executes services by assembly-qualified type name.
+    /// Used by message processors to dispatch incoming messages to the correct service
+    /// without compile-time knowledge of the concrete type.
+    /// </summary>
     public interface ICoreServiceRunner
     {
+        /// <summary>
+        /// Resolves the service identified by <paramref name="typeName"/> and runs it with the given request.
+        /// </summary>
+        /// <param name="typeName">Assembly-qualified type name of the service to run.</param>
+        /// <param name="request">The request payload.</param>
+        /// <param name="correlationId">Optional correlation identifier.</param>
+        /// <param name="IsLongRunningChild"><see langword="true"/> when this is a child spawned by a long-running parent.</param>
         Task<CoreResponseBase> RunAsync(string typeName, CoreRequestBase request, string? correlationId = null, bool IsLongRunningChild = false);
-        Task<CoreResponseBase> ResumeAsync(string typeName, string operationId);        
+
+        /// <summary>
+        /// Resolves the long-running service identified by <paramref name="typeName"/> and resumes it.
+        /// </summary>
+        /// <param name="typeName">Assembly-qualified type name of the long-running service to resume.</param>
+        /// <param name="operationId">The operation identifier assigned when the service was first started.</param>
+        Task<CoreResponseBase> ResumeAsync(string typeName, string operationId);
     }
 }

--- a/BaseLib.Core/Services/ICoreServiceStateStore.cs
+++ b/BaseLib.Core/Services/ICoreServiceStateStore.cs
@@ -1,8 +1,25 @@
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Persists and retrieves the field-level state of a suspended
+    /// <see cref="CoreLongRunningServiceBase{TRequest,TResponse}"/> so it can be
+    /// restored when all child operations have completed.
+    /// The AWS implementation stores state as JSON in S3 via <c>S3CoreServiceStateStore</c>.
+    /// </summary>
     public interface ICoreServiceStateStore
     {
+        /// <summary>
+        /// Persists the service state snapshot keyed by <paramref name="operationId"/>.
+        /// </summary>
+        /// <param name="operationId">Unique identifier for the suspended operation.</param>
+        /// <param name="state">Dictionary of field names to their current values.</param>
         Task WriteAsync(string operationId, IDictionary<string, object?> state);
+
+        /// <summary>
+        /// Retrieves the previously persisted state for the given <paramref name="operationId"/>.
+        /// </summary>
+        /// <param name="operationId">Unique identifier for the suspended operation.</param>
+        /// <returns>Dictionary of field names to their stored values.</returns>
         Task<IDictionary<string, object?>> ReadAsync(string operationId);
     }
 }

--- a/BaseLib.Core/Services/ICoreStatusEventSink.cs
+++ b/BaseLib.Core/Services/ICoreStatusEventSink.cs
@@ -2,8 +2,18 @@
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Publishes service status events to an external messaging system for
+    /// event-driven choreography between services.
+    /// Implement this interface to target a specific transport (e.g. SNS, Azure Service Bus).
+    /// Use <see cref="NullCoreEventSink"/> when no event publishing is needed.
+    /// </summary>
     public interface ICoreStatusEventSink
     {
+        /// <summary>
+        /// Publishes a <see cref="CoreStatusEvent"/> to the underlying transport.
+        /// </summary>
+        /// <param name="statusEvent">The event describing the current service status.</param>
         Task WriteAsync(CoreStatusEvent statusEvent);
     }
 }

--- a/BaseLib.Core/Services/ICoreStatusEventStore.cs
+++ b/BaseLib.Core/Services/ICoreStatusEventStore.cs
@@ -3,12 +3,20 @@ using BaseLib.Core.Models;
 namespace BaseLib.Core.Services
 {
     /// <summary>
-    /// Abstraction to write the events to a StatusEvent repository
+    /// Persists and retrieves <see cref="CoreStatusEvent"/> records for auditing and
+    /// long-running service coordination. Used by <see cref="ICoreLongRunningServiceManager"/>
+    /// implementations to track parent/child relationships.
     /// </summary>
     public interface ICoreStatusEventStore
     {
+        /// <summary>Persists the given <paramref name="statusEvent"/>.</summary>
+        /// <returns>The number of records written.</returns>
         Task<int> WriteAsync(CoreStatusEvent statusEvent);
-        Task<CoreStatusEvent> ReadAsync(string correlationId);
 
+        /// <summary>
+        /// Reads the most recent <see cref="CoreStatusEvent"/> for the given <paramref name="correlationId"/>.
+        /// </summary>
+        /// <param name="correlationId">The correlation identifier to look up.</param>
+        Task<CoreStatusEvent> ReadAsync(string correlationId);
     }
 }

--- a/BaseLib.Core/Services/IJournalEntryWriter.cs
+++ b/BaseLib.Core/Services/IJournalEntryWriter.cs
@@ -2,8 +2,21 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Persists a <see cref="JournalEntry"/> to a durable store after each service execution.
+    /// The default implementation targets MySQL via <c>BaseLib.Core.MySql</c>.
+    /// </summary>
+    /// <remarks>
+    /// Best practice: store only the journal entry (metadata) in a relational database.
+    /// Request and response payloads should be stored separately in a secure object store.
+    /// </remarks>
     public interface IJournalEntryWriter
     {
+        /// <summary>
+        /// Writes the <paramref name="entry"/> to the underlying store.
+        /// </summary>
+        /// <param name="entry">The journal entry to persist.</param>
+        /// <returns>The number of rows affected.</returns>
         Task<int> WriteAsync(JournalEntry entry);
     }
 }

--- a/BaseLib.Core/Services/IJournalEventHandler.cs
+++ b/BaseLib.Core/Services/IJournalEventHandler.cs
@@ -2,8 +2,18 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Converts a <see cref="CoreStatusEvent"/> into a <see cref="Models.JournalEntry"/> and
+    /// persists it via <see cref="IJournalEntryWriter"/>. Called by event processors after
+    /// each service execution to maintain an audit trail.
+    /// </summary>
     public interface IJournalEventHandler
     {
+        /// <summary>
+        /// Processes the <paramref name="statusEvent"/> and writes a journal entry.
+        /// </summary>
+        /// <param name="statusEvent">The status event to journal.</param>
+        /// <returns>The number of records written.</returns>
         Task<int> HandleAsync(CoreStatusEvent statusEvent);
     }
 }

--- a/BaseLib.Core/readme.md
+++ b/BaseLib.Core/readme.md
@@ -27,7 +27,7 @@ public class CheckoutRequest : CoreRequestBase
 ```
 
 ### Response
-Responses are derived from CoreResponseBase and contain a Succeeded property to indicate success. 
+Responses are derived from CoreResponseBase and contain a Succeeded property to indicate success.
 
 Example:
 
@@ -39,7 +39,7 @@ public class CheckoutResponse : CoreResponseBase
 ```
 
 ### Service Implementation
-Services inherit from `CoreServiceBase<TRequest,TResponse>`, where TRequest and TResponse are your custom request and response types. The core logic is implemented in the RunAsync() method. 
+Services inherit from `CoreServiceBase<TRequest,TResponse>`, where TRequest and TResponse are your custom request and response types. The core logic is implemented in the RunAsync() method.
 
 Example:
 
@@ -104,7 +104,7 @@ flowchart LR;
     Topic -- event -->s2-->CreateInvoiceService;
 ```
 
-Service required to report events need to use the build in constructor passing the ICoreStatusEventSink. 
+Service required to report events need to use the build in constructor passing the ICoreStatusEventSink.
 
 Example:
 
@@ -123,7 +123,162 @@ public class CheckoutService : CoreServiceBase<CheckoutRequest, CheckoutResponse
 }
 ```
 
+---
 
+## Long-Running Services
 
+Some operations need to fan out work to child services and wait for all of them to complete before producing a final result. `CoreLongRunningServiceBase<TRequest, TResponse>` handles this pattern.
 
+### How it works
 
+1. The parent service runs and spawns child services via `FireAsync` or `FireManyAsync`.
+2. After `RunAsync` completes, the framework detects pending children, serialises the service state, and suspends with status `Suspended`.
+3. When all children finish, an `ICoreLongRunningServiceManager` triggers `ResumeAsync` on the parent with the saved `operationId`.
+4. The parent restores its state and calls `ResumeAsync()` to produce the final response.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Parent as ParentService (LongRunning)
+    participant Fire as ICoreServiceFireOnly
+    participant Store as ICoreServiceStateStore
+    participant Manager as ICoreLongRunningServiceManager
+    participant Child as ChildService
+
+    Client->>Parent: RunAsync(request)
+    Parent->>Fire: FireManyAsync<ChildService>(requests)
+    Fire-->>Child: (async, fire-and-forget)
+    Parent->>Store: WriteAsync(operationId, state)
+    Parent-->>Client: Response (Suspended)
+
+    Child-->>Manager: StatusEvent (Finished)
+    Manager->>Parent: ResumeAsync(operationId)
+    Parent->>Store: ReadAsync(operationId)
+    Parent-->>Client: Final Response (Finished)
+```
+
+### Implementation
+
+```csharp
+public class BatchInvoiceService : CoreLongRunningServiceBase<BatchInvoiceRequest, BatchInvoiceResponse>
+{
+    private int[] _orderIds = [];
+
+    public BatchInvoiceService(
+        ICoreServiceFireOnly fireOnly,
+        ICoreServiceStateStore stateStore,
+        ICoreStatusEventSink? eventSink = null)
+        : base(fireOnly, stateStore, eventSink: eventSink) { }
+
+    protected override async Task<BatchInvoiceResponse> RunAsync()
+    {
+        _orderIds = this.Request.OrderIds;
+
+        // Fire one child per order — service suspends until all complete
+        await FireManyAsync<CreateInvoiceService>(
+            _orderIds.Select(id => new CreateInvoiceRequest { OrderId = id }));
+
+        return new BatchInvoiceResponse { Succeeded = true };
+    }
+
+    protected override Task<BatchInvoiceResponse> ResumeAsync()
+    {
+        // All children finished — produce final result
+        return Task.FromResult(new BatchInvoiceResponse
+        {
+            Succeeded = true,
+            InvoiceCount = _orderIds.Length
+        });
+    }
+}
+```
+
+### Required dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `ICoreServiceFireOnly` | Dispatches child service invocations without blocking |
+| `ICoreServiceStateStore` | Persists/restores service field state across suspension |
+| `ICoreStatusEventSink` | (Optional) Publishes lifecycle events |
+
+> AWS implementations: `SqsCoreServiceFireOnly` (fire), `S3CoreServiceStateStore` (state).
+
+---
+
+## Input Validation with FluentValidation
+
+Pass a `FluentValidation.IValidator<TRequest>` to the base constructor. If validation fails, the service returns a failed response with `ReasonCode = ValidationResultNotValid` — `RunAsync()` is never called.
+
+The `WithReasonCode` extension maps a domain enum value as the FluentValidation error code and message:
+
+```csharp
+public class CheckoutValidator : AbstractValidator<CheckoutRequest>
+{
+    public CheckoutValidator()
+    {
+        RuleFor(r => r.Items)
+            .NotEmpty()
+            .WithReasonCode(EcommerceReasonCode.NoItemsAvailable);
+    }
+}
+
+public class CheckoutService : CoreServiceBase<CheckoutRequest, CheckoutResponse>
+{
+    public CheckoutService(ICoreStatusEventSink? eventSink = null)
+        : base(validator: new CheckoutValidator(), eventSink: eventSink) { }
+
+    protected override async Task<CheckoutResponse> RunAsync()
+    {
+        // Only reached when validation passes
+    }
+}
+```
+
+---
+
+## Polymorphic JSON Serialization
+
+`PolymorphicConverter<T>` enables serialization of polymorphic object graphs (e.g. `CoreRequestBase` subclasses stored in `CoreStatusEvent`). It embeds a `___type` discriminator property with the assembly-qualified type name.
+
+**Usage** — register on `JsonSerializerOptions`:
+
+```csharp
+var options = new JsonSerializerOptions();
+options.Converters.Add(new PolymorphicConverter<CoreRequestBase>());
+
+var json = JsonSerializer.Serialize<CoreRequestBase>(myRequest, options);
+var restored = JsonSerializer.Deserialize<CoreRequestBase>(json, options);
+// restored is the correct concrete subclass
+```
+
+> `PolymorphicConverter` is used internally by `CoreSerializer` when serialising `CoreStatusEvent` payloads. You normally do not need to configure it manually.
+
+**Secure variant** — `SecurePolymorphicConverter<T>` works the same way but encrypts properties decorated with `[CoreSecret]` using an `IEncryptionKeyProvider`:
+
+```csharp
+options.Converters.Add(new SecurePolymorphicConverter<CoreRequestBase>(encryptionKeyProvider));
+```
+
+---
+
+## Serializers
+
+| Class | Description |
+|---|---|
+| `CoreSerializer` | Static helper using `System.Text.Json` with `PolymorphicConverter` pre-registered for `CoreRequestBase` and `CoreResponseBase`. Used internally by the framework. |
+| `CoreJsonSerializer` | `ICoreSerializer` implementation backed by `System.Text.Json`. |
+| `CoreSecureJsonSerializer` | `ICoreSerializer` implementation that encrypts `[CoreSecret]` annotated fields using `IEncryptionKeyProvider`. |
+
+---
+
+## Helper Methods
+
+`CoreServiceBase` exposes two convenience methods for building responses:
+
+```csharp
+// Fail with a reason code and optional messages
+return this.Fail(EcommerceReasonCode.NoItemsAvailable, "No stock remaining");
+
+// Succeed with an optional reason code
+return this.Succeed();
+```

--- a/readme.md
+++ b/readme.md
@@ -18,10 +18,34 @@ dotnet add package BaseLib.Core.AmazonCloud
 dotnet add package BaseLib.Core.MySql
 ```
 
+## Version Compatibility
 
+| BaseLib.Core | BaseLib.Core.AmazonCloud | BaseLib.Core.MySql | .NET |
+|---|---|---|---|
+| 3.1.x | 3.1.x | 3.1.x | net8.0 |
+
+All packages within the same minor version are compatible with each other. The `AmazonCloud` and `MySql` packages depend on `BaseLib.Core` of the same minor version (`3.1.*`).
 
 ## Contributing
-Contributions to BaseLib are welcome. Please submit your pull requests or open issues for discussion.
+
+Contributions are welcome. Please follow these steps:
+
+1. **Fork** the repository and create a feature branch from `master`.
+2. **Write or update tests** in `BaseLib.Core.Tests` for any changed behaviour.
+3. **Build and test** locally before submitting:
+   ```bash
+   dotnet build
+   dotnet test
+   ```
+4. **Document your changes**:
+   - Add XML doc comments (`/// <summary>`) to all new public types and members.
+   - Update the relevant `readme.md` if you add or change a feature.
+5. **Open a pull request** against `master` with a clear description of what changed and why.
+
+### Documentation standards
+- Public interfaces and classes must have `<summary>` XML doc comments.
+- Non-obvious parameters must have `<param>` comments.
+- New features should include a usage example in the module `readme.md`.
 
 ## License
 BaseLib is licensed under the MIT License. See the LICENSE file in the repository for more details.


### PR DESCRIPTION
## Summary

- Enable `<GenerateDocumentationFile>` in all 3 library `.csproj` files so missing XML docs surface as build warnings
- Add XML doc comments (`<summary>`, `<param>`, `<returns>`, `<remarks>`) to all 14 undocumented public interfaces across `BaseLib.Core`
- Expand all 4 README files with new sections covering previously undocumented features

## What's documented

**BaseLib.Core/readme.md**
- Long-running services: how suspension/resume works, sequence diagram, implementation example
- FluentValidation integration with `WithReasonCode` extension
- Polymorphic JSON serialization (`PolymorphicConverter`, `SecurePolymorphicConverter`)
- Serializer comparison table and `Fail`/`Succeed` helper methods

**BaseLib.Core.AmazonCloud/readme.md**
- DI configuration examples for all components (SNS, SQS, Secrets Manager, KMS, S3, SES)
- IAM permissions summary table
- Environment setup guide (local credentials vs IAM role)

**BaseLib.Core.MySql/readme.md**
- `LongRunningServiceManager` lifecycle table and `LONG_RUNNING_BATCH` schema
- Extension method reference (`SetWaitTimeout`, `IsTransient`, `IsDuplicate`)
- Troubleshooting section (connection drops, duplicate keys, `max_allowed_packet`)

**readme.md (root)**
- Version compatibility matrix
- Contributing guide with documentation standards

## Test plan

- [ ] `dotnet build` — verify no new errors; CS1591 warnings should appear only for members intentionally left undocumented
- [ ] Review rendered README on GitHub NuGet package pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)