### PR TITLE
docs: Complete XML documentation — zero CS1591 warnings

### DIFF
--- a/BaseLib.Core.AmazonCloud/CoreServiceMessageProcessorBase.cs
+++ b/BaseLib.Core.AmazonCloud/CoreServiceMessageProcessorBase.cs
@@ -6,15 +6,28 @@ using BaseLib.Core.Services;
 
 namespace BaseLib.Core.AmazonCloud
 {
+    /// <summary>
+    /// AWS Lambda handler that processes an SQS batch of service-dispatch messages.
+    /// Each message body is a JSON payload containing a service type name and either a
+    /// <c>RunAsync</c> request or a <c>ResumeAsync</c> operation ID.
+    /// Failed individual messages are returned as batch item failures so SQS can retry them.
+    /// Derive from this class and register it as your Lambda function handler.
+    /// </summary>
     public class CoreServiceMessageProcessorBase
     {
         private readonly ICoreServiceRunner runner;
 
+        /// <summary>Initializes the processor with the service runner used to dispatch messages.</summary>
+        /// <param name="runner">Runner that resolves and executes services by type name.</param>
         public CoreServiceMessageProcessorBase(ICoreServiceRunner runner)
         {
             this.runner = runner;
         }
 
+        /// <summary>
+        /// Lambda entry point. Processes all records in <paramref name="sqsEvent"/> concurrently
+        /// and returns failed message IDs as batch item failures.
+        /// </summary>
         public virtual async Task<SQSBatchResponse> HandleAsync(SQSEvent sqsEvent, ILambdaContext context)
         {
             var processingTasks = new Dictionary<string, Task>();

--- a/BaseLib.Core.AmazonCloud/Extensions/AmazonLambdaExtensions.cs
+++ b/BaseLib.Core.AmazonCloud/Extensions/AmazonLambdaExtensions.cs
@@ -2,8 +2,13 @@ using System.IO.Compression;
 
 namespace Amazon.Lambda.ApplicationLoadBalancerEvents
 {
+    /// <summary>Extension methods for AWS Lambda response types.</summary>
     public static class AmazonLambdaExtensions
     {
+        /// <summary>
+        /// GZip-compresses the response body, Base64-encodes it, and sets the
+        /// <c>Content-Encoding: gzip</c> header. Returns a new response object.
+        /// </summary>
         public static ApplicationLoadBalancerResponse ToGZip(this ApplicationLoadBalancerResponse response)
         {
             var headers = response.Headers ?? new Dictionary<string, string>();

--- a/BaseLib.Core.AmazonCloud/Extensions/AmazonS3Extensions.cs
+++ b/BaseLib.Core.AmazonCloud/Extensions/AmazonS3Extensions.cs
@@ -2,8 +2,10 @@ using Amazon.S3.Model;
 
 namespace Amazon.S3
 {
+    /// <summary>Extension methods for <see cref="IAmazonS3"/> that simplify common existence and retrieval checks.</summary>
     public static class AmazonS3Extensions
     {
+        /// <summary>Returns <see langword="true"/> if the object identified by <paramref name="key"/> exists in <paramref name="bucketName"/>.</summary>
         public static async Task<bool> ObjectExistsAsync(this IAmazonS3 s3, string bucketName, string key)
         {
             try

--- a/BaseLib.Core.AmazonCloud/Extensions/AwsCredentialsFactory.cs
+++ b/BaseLib.Core.AmazonCloud/Extensions/AwsCredentialsFactory.cs
@@ -1,7 +1,16 @@
 namespace Amazon.Runtime.CredentialManagement
 {
+    /// <summary>
+    /// Convenience factory that creates <see cref="AWSCredentials"/> from the named profile
+    /// specified in the <c>AWS_PROFILE</c> environment variable.
+    /// Intended for local development; in AWS environments use the IAM role attached to the compute resource.
+    /// </summary>
     public class AwsCredentialsFactory
     {
+        /// <summary>
+        /// Creates <see cref="AWSCredentials"/> from the profile named in the <c>AWS_PROFILE</c>
+        /// environment variable. Throws if the variable is not set or the profile is not found.
+        /// </summary>
         public static AWSCredentials Create()
         {
             var profileName = Environment.GetEnvironmentVariable("AWS_PROFILE");

--- a/BaseLib.Core.AmazonCloud/LongRunningServicesEventProcessorBase.cs
+++ b/BaseLib.Core.AmazonCloud/LongRunningServicesEventProcessorBase.cs
@@ -7,10 +7,19 @@ using BaseLib.Core.Serialization;
 
 namespace BaseLib.Core.Services.AmazonCloud
 {
+    /// <summary>
+    /// AWS Lambda handler that processes SQS batches of SNS-wrapped <see cref="CoreStatusEvent"/> messages
+    /// and drives the long-running service lifecycle via <see cref="ICoreLongRunningServiceManager"/>.
+    /// Events are grouped by correlation ID and processed in order: suspended parents first,
+    /// then finished children, then finished parents.
+    /// Derive from this class and register it as your Lambda function handler.
+    /// </summary>
     public class LongRunningServicesEventProcessorBase
     {
         private readonly ICoreLongRunningServiceManager longRunningServiceManager;
 
+        /// <summary>Initializes the processor with the manager that coordinates long-running service state.</summary>
+        /// <param name="longRunningServiceManager">Manager that handles parent/child lifecycle events.</param>
         public LongRunningServicesEventProcessorBase(ICoreLongRunningServiceManager longRunningServiceManager)
         {
             this.longRunningServiceManager = longRunningServiceManager;
@@ -21,6 +30,11 @@ namespace BaseLib.Core.Services.AmazonCloud
             public string? Message { get; set; }
         }
 
+        /// <summary>
+        /// Lambda entry point. Deserialises SNS notifications, groups events by correlation ID,
+        /// and delegates to <see cref="ICoreLongRunningServiceManager"/>. Returns failed message IDs
+        /// as batch item failures.
+        /// </summary>
         public virtual async Task<SQSBatchResponse> HandleAsync(SQSEvent sqsEvent, ILambdaContext context)
         {
             var groupsOfEvents = ExtractGroupsOfEvents(sqsEvent);

--- a/BaseLib.Core.AmazonCloud/Mail/AmazonEmailSender.cs
+++ b/BaseLib.Core.AmazonCloud/Mail/AmazonEmailSender.cs
@@ -6,14 +6,21 @@ using MimeKit;
 
 namespace BaseLib.Core.AmazonCloud.Mail;
 
+/// <summary>
+/// <see cref="IEmailSender"/> implementation that sends email via Amazon SES v2.
+/// Builds a raw MIME message from the <see cref="MimeMessage"/> and submits it to SES.
+/// </summary>
 public class AmazonEmailSender: IEmailSender
 {
     private readonly IAmazonSimpleEmailServiceV2 emailService;
 
+    /// <summary>Initializes the sender with an SES v2 client.</summary>
+    /// <param name="emailService">The SES v2 service client.</param>
     public AmazonEmailSender(IAmazonSimpleEmailServiceV2 emailService)
     {
         this.emailService = emailService;
     }
+    /// <inheritdoc/>
     public async Task<EmailResponse> SendAsync(MimeMessage message)
     {
         var sendEmailRequest = MapToAmazonRequest(message);

--- a/BaseLib.Core.AmazonCloud/S3CoreServiceStateStore.cs
+++ b/BaseLib.Core.AmazonCloud/S3CoreServiceStateStore.cs
@@ -5,6 +5,12 @@ using Amazon.S3.Model;
 
 namespace BaseLib.Core.Services.AmazonCloud
 {
+    /// <summary>
+    /// <see cref="ICoreServiceStateStore"/> implementation that persists suspended service state
+    /// as JSON objects in an S3 bucket. Each operation is stored as
+    /// <c>{folderName}/{operationId}.json</c>. Type information is preserved alongside each value
+    /// so the full field graph can be reconstructed on resume.
+    /// </summary>
     public class S3CoreServiceStateStore : ICoreServiceStateStore
     {
         private readonly IAmazonS3 s3;
@@ -17,6 +23,10 @@ namespace BaseLib.Core.Services.AmazonCloud
             WriteIndented = false
         };
 
+        /// <summary>Initializes the state store.</summary>
+        /// <param name="s3">S3 client.</param>
+        /// <param name="bucketName">Name of the S3 bucket used for state storage.</param>
+        /// <param name="folderName">S3 key prefix (folder). Defaults to <c>state</c>.</param>
         public S3CoreServiceStateStore(IAmazonS3 s3, string bucketName, string folderName = "state")
         {
             this.s3 = s3;

--- a/BaseLib.Core.AmazonCloud/S3CoreServiceStateStore.cs
+++ b/BaseLib.Core.AmazonCloud/S3CoreServiceStateStore.cs
@@ -34,6 +34,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             this.folderName = folderName;
         }
 
+        /// <inheritdoc/>
         public async Task<IDictionary<string, object?>> ReadAsync(string operationId)
         {
             // Fast path for invalid inputs
@@ -66,6 +67,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             );
         }
 
+        /// <inheritdoc/>
         public async Task WriteAsync(string operationId, IDictionary<string, object?> state)
         {
             // Create a dictionary with typed values

--- a/BaseLib.Core.AmazonCloud/Security/KmsEncryptionKeyProvider.cs
+++ b/BaseLib.Core.AmazonCloud/Security/KmsEncryptionKeyProvider.cs
@@ -3,11 +3,19 @@ using Amazon.KeyManagementService.Model;
 
 namespace BaseLib.Core.Security.AmazonCloud
 {
+    /// <summary>
+    /// <see cref="IEncryptionKeyProvider"/> implementation backed by AWS KMS.
+    /// Generates AES-256 data keys via <c>GenerateDataKey</c> and decrypts them via <c>Decrypt</c>.
+    /// Wrap with <c>S3CachedEncryptionProvider</c> to avoid a KMS call on every serialization.
+    /// </summary>
     public class KmsEncryptionKeyProvider : IEncryptionKeyProvider
     {
         private readonly IAmazonKeyManagementService kmsClient;
         private readonly string kmsKeyName;
 
+        /// <summary>Initializes the provider.</summary>
+        /// <param name="kmsClient">KMS service client.</param>
+        /// <param name="kmsKeyName">KMS key ID, alias (e.g. <c>alias/my-key</c>), or ARN.</param>
         public KmsEncryptionKeyProvider(IAmazonKeyManagementService kmsClient, string kmsKeyName)
         {
             this.kmsClient = kmsClient;
@@ -29,6 +37,7 @@ namespace BaseLib.Core.Security.AmazonCloud
         }
 
 
+        /// <inheritdoc/>
         public async Task<byte[]> UnwrapKeyAsync(byte[] wrappedKey)
         {
             var response = await kmsClient.DecryptAsync(new DecryptRequest

--- a/BaseLib.Core.AmazonCloud/Security/S3CachedEncryptionProvider.cs
+++ b/BaseLib.Core.AmazonCloud/Security/S3CachedEncryptionProvider.cs
@@ -19,6 +19,11 @@ namespace BaseLib.Core.Security.AmazonCloud
         private readonly string bucketName;
         private readonly string folderName;
         
+        /// <summary>Initializes the caching provider.</summary>
+        /// <param name="innerProvider">Underlying provider used to generate or unwrap keys when the cache misses.</param>
+        /// <param name="s3">S3 client used to read and write wrapped key files.</param>
+        /// <param name="bucketName">S3 bucket where wrapped key files are stored.</param>
+        /// <param name="folderName">S3 key prefix for key files. Defaults to <c>cache/keys</c>.</param>
         public S3CachedEncryptionProvider(IEncryptionKeyProvider innerProvider, IAmazonS3 s3, string bucketName, string folderName = "cache/keys")
         {
             this.innerProvider = innerProvider;
@@ -27,6 +32,7 @@ namespace BaseLib.Core.Security.AmazonCloud
             this.folderName = folderName;
         }
 
+        /// <inheritdoc/>
         public async Task<(byte[] key, byte[] wrappedKey)> GetEncryptionKeyAsync()
         {
             if (keyPair == null)
@@ -92,6 +98,7 @@ namespace BaseLib.Core.Security.AmazonCloud
             return objectKey;
         }
 
+        /// <inheritdoc/>
         public Task<byte[]> UnwrapKeyAsync(byte[] wrappedKey)
         {
             if (keyPair != null && keyPair.WrappedKey==wrappedKey)

--- a/BaseLib.Core.AmazonCloud/Services/AmazonSecretsVault.cs
+++ b/BaseLib.Core.AmazonCloud/Services/AmazonSecretsVault.cs
@@ -3,15 +3,22 @@ using Amazon.SecretsManager.Model;
 
 namespace BaseLib.Core.Security.AmazonCloud
 {
+    /// <summary>
+    /// <see cref="ICoreSecretsVault"/> implementation backed by AWS Secrets Manager.
+    /// Retrieves secret string values by name or ARN.
+    /// </summary>
     public class AmazonSecretsVault : ICoreSecretsVault
     {
         private readonly IAmazonSecretsManager secretsManager;
 
+        /// <summary>Initializes the vault with a Secrets Manager client.</summary>
+        /// <param name="amazonSecretsManager">The AWS Secrets Manager service client.</param>
         public AmazonSecretsVault(IAmazonSecretsManager amazonSecretsManager)
         {
             secretsManager = amazonSecretsManager;
         }
 
+        /// <inheritdoc/>
         public async Task<string> GetSecretValueAsync(string secretName)
         {
 

--- a/BaseLib.Core.AmazonCloud/Services/CoreStatusEventsStore.cs
+++ b/BaseLib.Core.AmazonCloud/Services/CoreStatusEventsStore.cs
@@ -14,6 +14,9 @@ namespace BaseLib.Core.Services.AmazonCloud
         private readonly string bucketName;
         private readonly string folderName;
 
+        /// <param name="s3">S3 client.</param>
+        /// <param name="bucketName">Bucket where event JSON files are stored.</param>
+        /// <param name="folderName">S3 key prefix. Defaults to <c>events</c>.</param>
         public CoreStatusEventsStore(IAmazonS3 s3, string bucketName, string folderName = "events")
         {
             this.s3 = s3;

--- a/BaseLib.Core.AmazonCloud/Services/CoreStatusEventsStore.cs
+++ b/BaseLib.Core.AmazonCloud/Services/CoreStatusEventsStore.cs
@@ -24,11 +24,13 @@ namespace BaseLib.Core.Services.AmazonCloud
             this.folderName = folderName;
         }
 
+        /// <inheritdoc/>
         public Task<CoreStatusEvent> ReadAsync(string correlationId)
         {
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc/>
         public async Task<int> WriteAsync(CoreStatusEvent statusEvent)
         {
             var keyName = $"{folderName}/{statusEvent.OperationId}.json";

--- a/BaseLib.Core.AmazonCloud/Services/SnsCoreStatusEventSink.cs
+++ b/BaseLib.Core.AmazonCloud/Services/SnsCoreStatusEventSink.cs
@@ -18,6 +18,9 @@ namespace BaseLib.Core.Services.AmazonCloud
         private readonly SemaphoreSlim initializationSemaphore = new SemaphoreSlim(1, 1);
         private bool isInitialized = false;
 
+        /// <summary>Initializes the sink.</summary>
+        /// <param name="sns">SNS service client.</param>
+        /// <param name="topicName">Plain topic name (not ARN). Append <c>.fifo</c> for FIFO topics.</param>
         public SnsCoreStatusEventSink(IAmazonSimpleNotificationService sns, string topicName)
         {
             this.sns = sns;
@@ -49,6 +52,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             }
         }
 
+        /// <inheritdoc/>
         public async Task WriteAsync(CoreStatusEvent statusEvent)
         {
             await InitializeAsync();

--- a/BaseLib.Core.AmazonCloud/Services/SqsCoreServiceFireOnly.cs
+++ b/BaseLib.Core.AmazonCloud/Services/SqsCoreServiceFireOnly.cs
@@ -8,6 +8,11 @@ using BaseLib.Core.Serialization;
 
 namespace BaseLib.Core.Services.AmazonCloud
 {
+    /// <summary>
+    /// <see cref="ICoreServiceFireOnly"/> implementation that dispatches service invocations
+    /// as messages to an SQS FIFO queue. Supports single and batch fire operations with
+    /// configurable concurrency. The queue URL is resolved lazily on first use.
+    /// </summary>
     public class SqsCoreServiceFireOnly : ICoreServiceFireOnly
     {
         private readonly IAmazonSQS sqs;
@@ -17,8 +22,12 @@ namespace BaseLib.Core.Services.AmazonCloud
         private readonly SemaphoreSlim initLock = new(1, 1);
         private readonly SemaphoreSlim concurrencyLock;
         private readonly int batchSize;
-        
 
+        /// <summary>Initializes the fire-only dispatcher.</summary>
+        /// <param name="sqs">SQS service client.</param>
+        /// <param name="queueName">Name of the SQS FIFO queue (must end with <c>.fifo</c>).</param>
+        /// <param name="maxConcurrency">Maximum number of concurrent batch-send operations. Defaults to 10.</param>
+        /// <param name="batchSize">Number of messages per SQS batch request. Defaults to 10.</param>
         public SqsCoreServiceFireOnly(IAmazonSQS sqs, string queueName, int maxConcurrency = 10, int batchSize = 10)
         {
             this.sqs = sqs;
@@ -27,6 +36,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             this.concurrencyLock = new SemaphoreSlim(maxConcurrency, maxConcurrency);
         }
 
+        /// <inheritdoc/>
         public Task FireAsync<TService>(CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false)
             where TService : ICoreServiceBase
         {
@@ -36,6 +46,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             return FireAsync(typeName, request, correlationId, isLongRunningChild);
         }
 
+        /// <inheritdoc/>
         public async Task FireAsync(string typeName, CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false)
         {
             await InitializeAsync();
@@ -59,6 +70,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             }
         }
 
+        /// <inheritdoc/>
         public Task ResumeAsync<TService>(string operationId, string? correlationId = null)
             where TService : ICoreLongRunningService
         {
@@ -69,6 +81,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             return ResumeAsync(typeName, operationId, correlationId);
         }
 
+        /// <inheritdoc/>
         public async Task ResumeAsync(string typeName, string operationId, string? correlationId = null)
         {
             await InitializeAsync();
@@ -127,6 +140,7 @@ namespace BaseLib.Core.Services.AmazonCloud
             return BitConverter.ToString(hashBytes);
         }
 
+        /// <inheritdoc/>
         public Task FireManyAsync<TService>(IEnumerable<CoreRequestBase> requests, string? correlationId = null, bool isLongRunningChild = false)
             where TService : ICoreServiceBase
         {

--- a/BaseLib.Core.AmazonCloud/Services/SqsCoreServiceFireOnly.cs
+++ b/BaseLib.Core.AmazonCloud/Services/SqsCoreServiceFireOnly.cs
@@ -152,6 +152,13 @@ namespace BaseLib.Core.Services.AmazonCloud
 
         }
 
+        /// <summary>
+        /// Dispatches multiple service invocations by type name to the SQS FIFO queue in concurrent batches.
+        /// </summary>
+        /// <param name="typeName">Assembly-qualified type name of the target service.</param>
+        /// <param name="requests">Collection of request payloads, one per child service invocation.</param>
+        /// <param name="correlationId">Correlation ID written into each message envelope.</param>
+        /// <param name="isLongRunningChild">Set to <see langword="true"/> when the invocations are children of a long-running parent.</param>
         public async Task FireManyAsync(string typeName, IEnumerable<CoreRequestBase> requests, string? correlationId = null, bool isLongRunningChild = false)
         {
             await InitializeAsync();

--- a/BaseLib.Core.AmazonCloud/SqsCoreStatusEventsListenerBase.cs
+++ b/BaseLib.Core.AmazonCloud/SqsCoreStatusEventsListenerBase.cs
@@ -11,6 +11,7 @@ namespace BaseLib.Core.AmazonCloud
     /// </summary>
     public abstract class SqsCoreStatusEventsListenerBase
     {
+        /// <summary>Lambda entry point. Deserialises SNS-wrapped status events and dispatches each to <see cref="HandleStatusEventAsync"/>.</summary>
         public virtual async Task<SQSBatchResponse> HandleAsync(SQSEvent sqsEvent, ILambdaContext context)
         {
             var events = MapEvents(sqsEvent);
@@ -25,6 +26,7 @@ namespace BaseLib.Core.AmazonCloud
             };
         }
 
+        /// <summary>Processes a pre-parsed dictionary of message-ID-to-event entries concurrently and returns the IDs of failed messages.</summary>
         protected virtual async Task<string[]> HandleAsync(Dictionary<string, CoreStatusEvent> events)
         {
             var processingTasks = new Dictionary<string, Task>();
@@ -51,6 +53,7 @@ namespace BaseLib.Core.AmazonCloud
 
         }
 
+        /// <summary>Deserialises SNS notifications from the SQS batch into a message-ID-to-event dictionary.</summary>
         protected virtual Dictionary<string, CoreStatusEvent> MapEvents(SQSEvent sqsEvent)
         {
             var events = new Dictionary<string, CoreStatusEvent>();
@@ -69,6 +72,7 @@ namespace BaseLib.Core.AmazonCloud
             return events;
         }
 
+        /// <summary>Override to implement custom handling for each deserialised <see cref="CoreStatusEvent"/>.</summary>
         protected abstract Task HandleStatusEventAsync(CoreStatusEvent coreEvent);
 
         private class SnsNotification

--- a/BaseLib.Core.MySql/Extensions/MySqlExtensionsEx.cs
+++ b/BaseLib.Core.MySql/Extensions/MySqlExtensionsEx.cs
@@ -2,6 +2,7 @@
 
 namespace MySql.Data.MySqlClient
 {
+    /// <summary>Extension methods for <see cref="MySqlConnection"/> and <see cref="MySqlException"/>.</summary>
     public static class MySqlExtensionsEx
     {
         private readonly static string[] transientMessages = new string[]{

--- a/BaseLib.Core.MySql/Extensions/MySqlExtensionsEx.cs
+++ b/BaseLib.Core.MySql/Extensions/MySqlExtensionsEx.cs
@@ -13,6 +13,9 @@ namespace MySql.Data.MySqlClient
             "Deadlock found"
         };
         
+        /// <summary>Sets the MySQL session <c>wait_timeout</c> variable for the given connection.</summary>
+        /// <param name="connection">An open <see cref="MySqlConnection"/>.</param>
+        /// <param name="timeout">Timeout value in seconds.</param>
         public static void SetWaitTimeout(this MySqlConnection connection, int timeout)
         {
             using( var command = new MySqlCommand($"SET session wait_timeout={timeout};", connection))
@@ -21,6 +24,9 @@ namespace MySql.Data.MySqlClient
             }
         }
 
+        /// <summary>Reads the current MySQL session <c>wait_timeout</c> value from the given connection.</summary>
+        /// <param name="connection">An open <see cref="MySqlConnection"/>.</param>
+        /// <returns>The current wait timeout in seconds, or <c>0</c> if the value cannot be read.</returns>
         public static int GetWaitTimeout(this MySqlConnection connection)
         {
             using( var command = new MySqlCommand("SHOW VARIABLES LIKE 'wait_timeout';", connection))
@@ -34,6 +40,8 @@ namespace MySql.Data.MySqlClient
             }
         }
 
+        /// <summary>Returns <see langword="true"/> when the exception message indicates a transient MySQL error that may succeed on retry (e.g. connection drops, deadlocks, timeouts).</summary>
+        /// <param name="ex">The MySQL exception to inspect.</param>
         public static bool IsTransient(this MySqlException ex)
         {
             var message = ex.Message;
@@ -42,6 +50,8 @@ namespace MySql.Data.MySqlClient
             return isTransient;
         }
 
+        /// <summary>Returns <see langword="true"/> when the exception message indicates a duplicate-key violation.</summary>
+        /// <param name="ex">The MySQL exception to inspect.</param>
         public static bool IsDuplicate(this MySqlException ex)
         {
             return ex.Message.Contains("duplicate");

--- a/BaseLib.Core.MySql/Services/JournalEntryWriter.cs
+++ b/BaseLib.Core.MySql/Services/JournalEntryWriter.cs
@@ -46,11 +46,14 @@ namespace BaseLib.Core.Services.MySql
             WHERE
                 OPERATION_ID = @OPERATION_ID;
         ";
+        /// <summary>Initializes the writer with an open MySQL connection.</summary>
+        /// <param name="connection">An open <see cref="MySqlConnection"/> used for all write operations.</param>
         public JournalEntryWriter(MySqlConnection connection)
         {
             this.connection = connection;
         }
 
+        /// <inheritdoc/>
         public async Task<int> WriteAsync(JournalEntry entry)
         {
             if (entry.Status == CoreServiceStatus.Started)

--- a/BaseLib.Core.MySql/Services/LongRunningServiceManager.cs
+++ b/BaseLib.Core.MySql/Services/LongRunningServiceManager.cs
@@ -7,6 +7,11 @@ using MySql.Data.MySqlClient;
 namespace BaseLib.Core.Services.MySql
 {
 
+    /// <summary>
+    /// MySQL-backed implementation of <see cref="ICoreLongRunningServiceManager"/> that persists
+    /// long-running batch control records in the <c>LONG_RUNNING_BATCH</c> table and triggers
+    /// <see cref="ICoreServiceFireOnly.ResumeAsync"/> when all child services have completed.
+    /// </summary>
     public class LongRunningServiceManager : ICoreLongRunningServiceManager
     {
         private readonly Func<MySqlConnection> connectionFactory;
@@ -164,11 +169,13 @@ namespace BaseLib.Core.Services.MySql
 
         }
 
+        /// <inheritdoc/>
         public async Task HandleParentFinishedAsync(CoreStatusEvent coreEvent)
         {
             await this.UpdateFinishedBatchAsync(coreEvent);
         }
 
+        /// <inheritdoc/>
         public async Task HandleChildrenFinishedAsync(CoreStatusEvent[] coreEvent)
         {
             if (coreEvent == null || coreEvent.Length == 0)

--- a/BaseLib.Core.MySql/Services/LongRunningServiceManager.cs
+++ b/BaseLib.Core.MySql/Services/LongRunningServiceManager.cs
@@ -115,6 +115,9 @@ namespace BaseLib.Core.Services.MySql
                 OPERATION_ID = @OPERATION_ID
         ";
 
+        /// <summary>Initializes the manager.</summary>
+        /// <param name="connectionFactory">Factory that creates and opens a <see cref="MySqlConnection"/> on demand.</param>
+        /// <param name="invoker">Fire-only dispatcher used to resume parent services when all children finish.</param>
         public LongRunningServiceManager(Func<MySqlConnection> connectionFactory, ICoreServiceFireOnly invoker)
         {
             this.connectionFactory = connectionFactory;

--- a/BaseLib.Core/Extensions/CoreReasonCodeExtensions.cs
+++ b/BaseLib.Core/Extensions/CoreReasonCodeExtensions.cs
@@ -3,6 +3,7 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Extensions
 {
+    /// <summary>Extension methods for <see cref="CoreReasonCode"/>.</summary>
     public static class CoreReasonCodeExtensions
     {
         /// <summary>

--- a/BaseLib.Core/Extensions/CoreServicesExtensions.cs
+++ b/BaseLib.Core/Extensions/CoreServicesExtensions.cs
@@ -5,8 +5,15 @@ using BaseLib.Core.Serialization;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>Extension methods for <see cref="ICoreServiceRunner"/>.</summary>
     public static class CoreServicesExtensions
     {
+        /// <summary>
+        /// Deserializes a JSON message body and dispatches it to the appropriate <c>RunAsync</c> or
+        /// <c>ResumeAsync</c> method on the runner.
+        /// </summary>
+        /// <param name="runner">The runner that resolves and executes services.</param>
+        /// <param name="messageBody">JSON-encoded payload produced by <see cref="ICoreServiceFireOnly"/>.</param>
         [Obsolete("Derive processor from  CoreServiceMessageProcessorBase instead")]
         public static async Task RunAsync(this ICoreServiceRunner runner, string messageBody)
         {

--- a/BaseLib.Core/Extensions/DbDataReaderExtensionsEx.cs
+++ b/BaseLib.Core/Extensions/DbDataReaderExtensionsEx.cs
@@ -6,54 +6,63 @@ namespace System.Data.Common
     /// </summary> 
     public static class DbDataReaderExtensionsEx
     {
+        /// <summary>Reads a <see cref="string"/> column by name, returning <see langword="null"/> for <c>DBNull</c>.</summary>
         public static string? GetStringEx(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToString(value) : null;
         }
 
+        /// <summary>Reads an <see cref="long"/> column by name, returning <c>0</c> for <c>DBNull</c>.</summary>
         public static long GetInt64Ex(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToInt64(value) : 0;
         }
 
+        /// <summary>Reads an <see cref="int"/> column by name, returning <c>0</c> for <c>DBNull</c>.</summary>
         public static int GetInt32Ex(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToInt32(value) : 0;
         }
 
+        /// <summary>Reads a <see cref="short"/> column by name, returning <c>0</c> for <c>DBNull</c>.</summary>
         public static short GetInt16Ex(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToInt16(value) : (short)0;
         }
 
+        /// <summary>Reads a <see cref="DateTime"/> column by name, returning <see cref="DateTime.MinValue"/> for <c>DBNull</c>.</summary>
         public static DateTime GetDateTimeEx(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToDateTime(value) : DateTime.MinValue;
         }
 
+        /// <summary>Reads a <see cref="bool"/> column by name, returning <see langword="false"/> for <c>DBNull</c>.</summary>
         public static bool GetBooleanEx(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToBoolean(value) : false;
         }
 
+        /// <summary>Reads a <see cref="double"/> column by name, returning <c>0</c> for <c>DBNull</c>.</summary>
         public static double GetDoubleEx(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToDouble(value) : 0;
         }
 
+        /// <summary>Reads a <see cref="decimal"/> column by name, returning <c>0</c> for <c>DBNull</c>.</summary>
         public static decimal GetDecimalEx(this DbDataReader reader, string name)
         {
             var value = reader[name];
             return (value != null && value != DBNull.Value) ? Convert.ToDecimal(value) : 0;
         }
 
+        /// <summary>Reads a string column and parses it as <typeparamref name="EnumT"/>, returning the default value for <c>DBNull</c> or an unrecognised string.</summary>
         public static EnumT GetEnumEx<EnumT>(this DbDataReader reader, string name) where EnumT : struct, Enum
         {
             var value = reader.GetStringEx(name);

--- a/BaseLib.Core/Extensions/FluentValidationExtensions.cs
+++ b/BaseLib.Core/Extensions/FluentValidationExtensions.cs
@@ -2,8 +2,14 @@
 
 namespace FluentValidation
 {
+    /// <summary>Extension methods that integrate <c>BaseLib.Core</c> reason codes with FluentValidation rules.</summary>
     public static class FluentValidationExtensions
     {
+        /// <summary>
+        /// Sets the FluentValidation error code and message from a domain enum value decorated with
+        /// <see cref="System.ComponentModel.DescriptionAttribute"/>.
+        /// The numeric enum value becomes the error code and the description becomes the error message.
+        /// </summary>
         public static IRuleBuilderOptions<T, TProperty> WithReasonCode<T, TProperty>(this IRuleBuilderOptions<T, TProperty> rule, Enum reasonCode, params string[] messages)
         {
             DefaultValidatorOptions.Configurable(rule).Current.ErrorCode = Convert.ToInt32(reasonCode).ToString();

--- a/BaseLib.Core/Extensions/StringExtensions.cs
+++ b/BaseLib.Core/Extensions/StringExtensions.cs
@@ -7,8 +7,13 @@ using System.Text.RegularExpressions;
 
 namespace System
 {
+    /// <summary>General-purpose extension methods for <see cref="string"/>.</summary>
     public static class StringExtensions
     {
+        /// <summary>
+        /// Parses a delimited key=value string into a dictionary.
+        /// Defaults to <c>key=value;key2=value2</c> format.
+        /// </summary>
         public static Dictionary<string, string> ToDictionary(this string text, char valueSeparator = '=', char pairSeparator = ';')
         {
             return text.Split(new char[] { pairSeparator }, StringSplitOptions.RemoveEmptyEntries)
@@ -16,16 +21,19 @@ namespace System
                 .ToDictionary(t => t[0].Trim(), t => t[1].Trim(), StringComparer.InvariantCultureIgnoreCase);
         }
 
+        /// <summary>Converts the string to a <see cref="Stream"/> encoded as UTF-8.</summary>
         public static Stream ToStream(this string s)
         {
             return s.ToStream(Encoding.UTF8);
         }
 
+        /// <summary>Converts the string to a <see cref="Stream"/> using the specified <paramref name="encoding"/>.</summary>
         public static Stream ToStream(this string s, Encoding encoding)
         {
             return new MemoryStream(encoding.GetBytes(s));
         }
 
+        /// <summary>Attempts to decode a Base64 string. Returns <see langword="false"/> if the input is not valid Base64.</summary>
         public static bool TryConvertFromBase64String(string s, out byte[] bytes)
         {
             try
@@ -42,11 +50,13 @@ namespace System
 
         }
 
+        /// <summary>Converts the string to camelCase, normalising special characters first.</summary>
         public static string ToCamelCase(this string text)
         {
             return GetCasedString(text.NormalizeSpecialChars(), false);
         }
 
+        /// <summary>Converts the string to PascalCase, normalising special characters first.</summary>
         public static string ToPascalCase(this string text)
         {
             return GetCasedString(text.NormalizeSpecialChars());
@@ -76,6 +86,10 @@ namespace System
             return sb.ToString();
         }
 
+        /// <summary>
+        /// Replaces accented Latin characters (U+00C0–U+00FF) with their ASCII equivalents
+        /// and converts underscores to spaces. Prefixes a leading underscore if the string starts with a digit.
+        /// </summary>
         public static string NormalizeSpecialChars(this string text)
         {
             var buffer = text.ToCharArray();

--- a/BaseLib.Core/Extensions/SystemExtensions.cs
+++ b/BaseLib.Core/Extensions/SystemExtensions.cs
@@ -2,8 +2,14 @@
 
 namespace System
 {
+    /// <summary>Extension methods for core .NET types.</summary>
     public static class SystemExtensions
     {
+        /// <summary>
+        /// Returns the <see cref="System.ComponentModel.DescriptionAttribute"/> value for an enum member,
+        /// falling back to the member name if no attribute is present.
+        /// Supports <see cref="FlagsAttribute"/> enums with multiple combined values.
+        /// </summary>
         public static string GetDescription(this Enum @enum)
         {
             var enumString = @enum.ToString();

--- a/BaseLib.Core/Extensions/XmlExtensions.cs
+++ b/BaseLib.Core/Extensions/XmlExtensions.cs
@@ -4,8 +4,12 @@ using System.Xml.Xsl;
 
 namespace System.Xml
 {
-   //fix self closing tag on xml, required for serialization
-   public class SelfClosingTagsFixer
+    /// <summary>
+    /// Applies an XSLT transform that expands self-closing XML tags into explicit open/close pairs
+    /// (e.g. <c>&lt;tag/&gt;</c> → <c>&lt;tag&gt;&lt;/tag&gt;</c>).
+    /// Required before deserializing XML produced by some .NET serializers.
+    /// </summary>
+    public class SelfClosingTagsFixer
     {
         private static readonly XslCompiledTransform transform ;
 
@@ -31,6 +35,7 @@ namespace System.Xml
             }
         }
 
+        /// <summary>Applies the self-closing-tag fix transform to <paramref name="source"/> and returns the result as a new <see cref="Stream"/>.</summary>
         public static Stream Fix(Stream source)
         {
             var target = new MemoryStream();

--- a/BaseLib.Core/Extensions/XslExtensions.cs
+++ b/BaseLib.Core/Extensions/XslExtensions.cs
@@ -5,8 +5,10 @@ using System.Xml.Xsl;
 
 namespace BaseLib.Core.Extensions
 {
+    /// <summary>Extension methods for <see cref="XslCompiledTransform"/> and <see cref="XsltArgumentList"/>.</summary>
     public static class XslExtensions
     {
+        /// <summary>Applies the XSLT transform to <paramref name="source"/> and returns the output as a rewound <see cref="Stream"/>.</summary>
         public static Stream Transform(this XslCompiledTransform xslt, Stream source, XsltArgumentList? arguments = null)
         {
             var output = new MemoryStream();
@@ -20,6 +22,7 @@ namespace BaseLib.Core.Extensions
             return output;
         }
 
+        /// <summary>Loads a stream as an <see cref="System.Xml.XPath.XPathNavigator"/> and adds it as an XSLT parameter.</summary>
         public static void AddNavigatorParam(this XsltArgumentList arguments, string name, string namespaceUri, Stream stream)
         {
             var document = new XPathDocument(stream);

--- a/BaseLib.Core/Mail/EmailMessageFactory.cs
+++ b/BaseLib.Core/Mail/EmailMessageFactory.cs
@@ -4,8 +4,21 @@ using MimeKit.Text;
 
 namespace BaseLib.Core.Mail;
 
+/// <summary>Factory for building <see cref="MimeMessage"/> instances ready to pass to <see cref="IEmailSender"/>.</summary>
 public static class EmailMessageFactory
 {
+    /// <summary>
+    /// Constructs a <see cref="MimeMessage"/> with the supplied recipients, subject, body, and optional
+    /// CC, BCC, and file attachments.
+    /// </summary>
+    /// <param name="fromMail">Sender email address.</param>
+    /// <param name="Tos">Required list of To recipients.</param>
+    /// <param name="subject">Email subject line.</param>
+    /// <param name="content">Email body content.</param>
+    /// <param name="format">Body format — defaults to HTML.</param>
+    /// <param name="bccs">Optional BCC recipients.</param>
+    /// <param name="ccs">Optional CC recipients.</param>
+    /// <param name="attachments">Optional file attachments.</param>
     public static MimeMessage Create(
         string fromMail, IEnumerable<string> Tos, string subject, string content, TextFormat format = TextFormat.Html, IEnumerable<string>? bccs = null,
         IEnumerable<string>? ccs = null, IEnumerable<FileAttachment>? attachments = null)

--- a/BaseLib.Core/Mail/FileAttachment.cs
+++ b/BaseLib.Core/Mail/FileAttachment.cs
@@ -1,7 +1,11 @@
 namespace BaseLib.Core.Mail;
+/// <summary>Represents a file to attach to an email message built with <see cref="EmailMessageFactory"/>.</summary>
 public class FileAttachment
 {
+    /// <summary>Stream containing the file contents.</summary>
     public Stream? Stream { get; set; }
+    /// <summary>File name shown in the email client (e.g. <c>invoice.pdf</c>).</summary>
     public string? FileName { get; set; }
+    /// <summary>MIME media type (e.g. <c>application/pdf</c>). Defaults to <c>application/octet-stream</c> if not set.</summary>
     public string? MediaType { get; set; }
 }

--- a/BaseLib.Core/Models/CoreReasonCode.cs
+++ b/BaseLib.Core/Models/CoreReasonCode.cs
@@ -11,121 +11,89 @@ namespace BaseLib.Core.Models
     /// </summary>
     public record CoreReasonCode(int Value, string Description) : IConvertible
     {
+        /// <summary>A <see cref="CoreReasonCode"/> that maps to <see cref="CoreServiceReasonCode.Undefined"/> (value 0).</summary>
         public static CoreReasonCode Null { get { return CoreServiceReasonCode.Undefined; } }
+        /// <summary>A <see cref="CoreReasonCode"/> that maps to <see cref="CoreServiceReasonCode.Succeeded"/> (value 1).</summary>
         public static CoreReasonCode Succeeded { get { return CoreServiceReasonCode.Succeeded; } }
+        /// <summary>A <see cref="CoreReasonCode"/> that maps to <see cref="CoreServiceReasonCode.Failed"/> (value 2).</summary>
         public static CoreReasonCode Failed { get { return CoreServiceReasonCode.Failed; } }
+
+        /// <summary>Initializes a <see cref="CoreReasonCode"/> with the <see cref="CoreServiceReasonCode.Undefined"/> value.</summary>
         public CoreReasonCode(): this(CoreServiceReasonCode.Undefined)
         {
         }
 
+        /// <summary>Implicitly converts any <see cref="Enum"/> value to a <see cref="CoreReasonCode"/>.</summary>
+        /// <param name="enumValue">The enum value to convert.</param>
         public static implicit operator CoreReasonCode(Enum enumValue)
             => new CoreReasonCode(Convert.ToInt32(enumValue), enumValue.GetDescription());
 
+        /// <summary>Returns <see langword="true"/> when the reason code's numeric value equals the given enum.</summary>
         public static bool operator ==(CoreReasonCode reasonCode, Enum enumValue)
             => reasonCode.Value == Convert.ToInt32(enumValue);
 
+        /// <summary>Returns <see langword="true"/> when the reason code's numeric value does not equal the given enum.</summary>
         public static bool operator !=(CoreReasonCode reasonCode, Enum enumValue)
             => !(reasonCode == enumValue);
 
+        /// <summary>Returns <see langword="true"/> when the reason code's numeric value equals the given integer.</summary>
         public static bool operator ==(CoreReasonCode reasonCode, Int32 intValue)
             => reasonCode.Value == intValue;
 
+        /// <summary>Returns <see langword="true"/> when the reason code's numeric value does not equal the given integer.</summary>
         public static bool operator !=(CoreReasonCode reasonCode, Int32 intValue)
             => !(reasonCode == intValue);
 
-
+        /// <summary>Explicitly converts a <see cref="CoreReasonCode"/> to its underlying <see cref="int"/> value.</summary>
+        /// <param name="reasonCode">The reason code to convert.</param>
         public static explicit operator int(CoreReasonCode reasonCode)
             => reasonCode.Value;
 
+        /// <summary>Converts <see cref="Value"/> to the specified enum type <typeparamref name="T"/>.</summary>
+        /// <typeparam name="T">Target enum type.</typeparam>
+        /// <returns>The enum member whose underlying value matches <see cref="Value"/>.</returns>
         public T ToEnum<T>() where T : struct, Enum
         {
             return (T)Enum.ToObject(typeof(T), Value);
         }
 
-        // Implement IConvertible
+        /// <inheritdoc/>
         public TypeCode GetTypeCode()
         {
             return TypeCode.Int32;
         }
 
-        public int ToInt32(IFormatProvider? provider)
-        {
-            return Value;
-        }
-
-        public bool ToBoolean(IFormatProvider? provider)
-        {
-            return Convert.ToBoolean(Value, provider);
-        }
-
-        public byte ToByte(IFormatProvider? provider)
-        {
-            return Convert.ToByte(Value, provider);
-        }
-
-        public char ToChar(IFormatProvider? provider)
-        {
-            return Convert.ToChar(Value, provider);
-        }
-
-        public DateTime ToDateTime(IFormatProvider? provider)
-        {
-            return Convert.ToDateTime(Value, provider);
-        }
-
-        public decimal ToDecimal(IFormatProvider? provider)
-        {
-            return Convert.ToDecimal(Value, provider);
-        }
-
-        public double ToDouble(IFormatProvider? provider)
-        {
-            return Convert.ToDouble(Value, provider);
-        }
-
-        public short ToInt16(IFormatProvider? provider)
-        {
-            return Convert.ToInt16(Value, provider);
-        }
-
-        public long ToInt64(IFormatProvider? provider)
-        {
-            return Convert.ToInt64(Value, provider);
-        }
-
-        public sbyte ToSByte(IFormatProvider? provider)
-        {
-            return Convert.ToSByte(Value, provider);
-        }
-
-        public float ToSingle(IFormatProvider? provider)
-        {
-            return Convert.ToSingle(Value, provider);
-        }
-
-        public string ToString(IFormatProvider? provider)
-        {
-            return Convert.ToString(Value, provider);
-        }
-
-        public object ToType(Type conversionType, IFormatProvider? provider)
-        {
-            return Convert.ChangeType(Value, conversionType, provider);
-        }
-
-        public ushort ToUInt16(IFormatProvider? provider)
-        {
-            return Convert.ToUInt16(Value, provider);
-        }
-
-        public uint ToUInt32(IFormatProvider? provider)
-        {
-            return Convert.ToUInt32(Value, provider);
-        }
-
-        public ulong ToUInt64(IFormatProvider? provider)
-        {
-            return Convert.ToUInt64(Value, provider);
-        }
+        /// <inheritdoc/>
+        public int ToInt32(IFormatProvider? provider) => Value;
+        /// <inheritdoc/>
+        public bool ToBoolean(IFormatProvider? provider) => Convert.ToBoolean(Value, provider);
+        /// <inheritdoc/>
+        public byte ToByte(IFormatProvider? provider) => Convert.ToByte(Value, provider);
+        /// <inheritdoc/>
+        public char ToChar(IFormatProvider? provider) => Convert.ToChar(Value, provider);
+        /// <inheritdoc/>
+        public DateTime ToDateTime(IFormatProvider? provider) => Convert.ToDateTime(Value, provider);
+        /// <inheritdoc/>
+        public decimal ToDecimal(IFormatProvider? provider) => Convert.ToDecimal(Value, provider);
+        /// <inheritdoc/>
+        public double ToDouble(IFormatProvider? provider) => Convert.ToDouble(Value, provider);
+        /// <inheritdoc/>
+        public short ToInt16(IFormatProvider? provider) => Convert.ToInt16(Value, provider);
+        /// <inheritdoc/>
+        public long ToInt64(IFormatProvider? provider) => Convert.ToInt64(Value, provider);
+        /// <inheritdoc/>
+        public sbyte ToSByte(IFormatProvider? provider) => Convert.ToSByte(Value, provider);
+        /// <inheritdoc/>
+        public float ToSingle(IFormatProvider? provider) => Convert.ToSingle(Value, provider);
+        /// <inheritdoc/>
+        public string ToString(IFormatProvider? provider) => Convert.ToString(Value, provider);
+        /// <inheritdoc/>
+        public object ToType(Type conversionType, IFormatProvider? provider) => Convert.ChangeType(Value, conversionType, provider);
+        /// <inheritdoc/>
+        public ushort ToUInt16(IFormatProvider? provider) => Convert.ToUInt16(Value, provider);
+        /// <inheritdoc/>
+        public uint ToUInt32(IFormatProvider? provider) => Convert.ToUInt32(Value, provider);
+        /// <inheritdoc/>
+        public ulong ToUInt64(IFormatProvider? provider) => Convert.ToUInt64(Value, provider);
     }
 }

--- a/BaseLib.Core/Models/CoreReasonCode.cs
+++ b/BaseLib.Core/Models/CoreReasonCode.cs
@@ -3,6 +3,12 @@ using BaseLib.Core.Services;
 
 namespace BaseLib.Core.Models
 {
+    /// <summary>
+    /// Immutable value object that carries a numeric reason code and its human-readable description.
+    /// Implicitly converts from any <see cref="Enum"/> so domain enums can be assigned directly to
+    /// response <c>ReasonCode</c> properties. Implements <see cref="IConvertible"/> so it can be
+    /// used wherever an <see cref="int"/> is expected (e.g. database parameters).
+    /// </summary>
     public record CoreReasonCode(int Value, string Description) : IConvertible
     {
         public static CoreReasonCode Null { get { return CoreServiceReasonCode.Undefined; } }

--- a/BaseLib.Core/Models/CoreRequestBase.cs
+++ b/BaseLib.Core/Models/CoreRequestBase.cs
@@ -1,5 +1,9 @@
 ﻿namespace BaseLib.Core.Models
 {
+    /// <summary>
+    /// Base class for all service request objects. Derive from this class to define the
+    /// input contract for a <c>CoreServiceBase&lt;TRequest, TResponse&gt;</c> implementation.
+    /// </summary>
     public abstract class CoreRequestBase
     {
     }

--- a/BaseLib.Core/Models/CoreResponseBase.cs
+++ b/BaseLib.Core/Models/CoreResponseBase.cs
@@ -1,10 +1,18 @@
 ﻿namespace BaseLib.Core.Models
 {
+    /// <summary>
+    /// Base class for all service response objects. Derive from this class to define the
+    /// output contract for a <c>CoreServiceBase&lt;TRequest, TResponse&gt;</c> implementation.
+    /// </summary>
     public abstract class CoreResponseBase
     {
+        /// <summary>Unique identifier assigned to this specific service execution.</summary>
         public string? OperationId { get; set; }
+        /// <summary><see langword="true"/> if the service completed without errors; otherwise <see langword="false"/>.</summary>
         public bool Succeeded { get; set; }
+        /// <summary>Structured reason code describing the outcome. Defaults to <see cref="CoreReasonCode.Null"/> (Undefined).</summary>
         public CoreReasonCode ReasonCode { get; set; } = CoreReasonCode.Null;
+        /// <summary>Optional informational or error messages produced during execution.</summary>
         public string[] Messages { get; set; } = [];
     }
 }

--- a/BaseLib.Core/Models/CoreServiceStatus.cs
+++ b/BaseLib.Core/Models/CoreServiceStatus.cs
@@ -1,10 +1,15 @@
 namespace BaseLib.Core.Models
 {
+    /// <summary>Lifecycle states of a service execution.</summary>
     public enum CoreServiceStatus
     {
+        /// <summary>The service has begun processing the request.</summary>
         Started,
+        /// <summary>The service has completed (successfully or with an error).</summary>
         Finished,
+        /// <summary>A long-running service is suspended while awaiting child completions.</summary>
         Suspended,
+        /// <summary>A previously suspended long-running service has been resumed.</summary>
         Resumed
     }
 }

--- a/BaseLib.Core/Models/CoreStatusEvent.cs
+++ b/BaseLib.Core/Models/CoreStatusEvent.cs
@@ -1,21 +1,38 @@
 namespace BaseLib.Core.Models
 {
+    /// <summary>
+    /// Snapshot of a service execution published to <see cref="Services.ICoreStatusEventSink"/> at
+    /// the start and end (and on suspension) of each service run. Consumed by event processors to
+    /// drive journaling, long-running service coordination, and downstream choreography.
+    /// </summary>
     public class CoreStatusEvent
     {
+        /// <summary>Assembly-qualified type name of the service (e.g. <c>MyApp.CheckoutService, MyApp</c>).</summary>
         public string? TypeName { get; set; }
+        /// <summary>Assembly name of the module that owns the service.</summary>
         public string? ModuleName { get; set; }
+        /// <summary>Short class name of the service.</summary>
         public string? ServiceName { get; set; }
+        /// <summary>Current lifecycle status of the service execution.</summary>
         public CoreServiceStatus Status { get; set; }
+        /// <summary>UTC timestamp when the service started.</summary>
         public DateTimeOffset StartedOn { get; set; }
+        /// <summary>UTC timestamp when the service finished or was suspended.</summary>
         public DateTimeOffset FinishedOn { get; set; }
+        /// <summary>Unique identifier for this execution, assigned by the framework.</summary>
         public string? OperationId { get; set; }
+        /// <summary>Correlation identifier linking related operations (e.g. parent/child in long-running flows).</summary>
         public string? CorrelationId { get; set; }
+        /// <summary>The request payload that triggered this execution.</summary>
         public CoreRequestBase? Request { get; set; }
+        /// <summary>The response produced by the service, or <see langword="null"/> if not yet finished.</summary>
         public CoreResponseBase? Response { get; set; }
+        /// <summary><see langword="true"/> when this event is from a long-running parent service.</summary>
         public bool IsLongRunningService { get; set; }
+        /// <summary>Number of child services spawned by a long-running parent.</summary>
         public int ChildrenCount { get; set; }
+        /// <summary><see langword="true"/> when this event is from a child spawned by a long-running parent.</summary>
         public bool IsLongRunningChild { get; set; }
-        
     }
 }
 

--- a/BaseLib.Core/Models/JournalEntry.cs
+++ b/BaseLib.Core/Models/JournalEntry.cs
@@ -1,23 +1,32 @@
 namespace BaseLib.Core.Models
 {
+    /// <summary>
+    /// Audit record written to the JOURNAL table after each service execution.
+    /// Contains metadata only — request/response payloads should be stored separately.
+    /// </summary>
     public class JournalEntry
     {
+        /// <summary>Short class name of the service that produced this entry.</summary>
         public string? ServiceName { get; set; }
-
+        /// <summary>Lifecycle status at the time of writing.</summary>
         public CoreServiceStatus Status { get; set; }
-
+        /// <summary>UTC timestamp when the service started.</summary>
         public DateTimeOffset StartedOn { get; set; }
-
+        /// <summary>UTC timestamp when the service finished.</summary>
         public DateTimeOffset FinishedOn { get; set; }
-
+        /// <summary>Unique operation identifier assigned by the framework.</summary>
         public string? OperationId { get; set; }
-
+        /// <summary>Correlation identifier linking related operations.</summary>
         public string? CorrelationId { get; set; }
+        /// <summary><see langword="true"/> if the service completed successfully.</summary>
         public bool Succeeded { get; set; }
+        /// <summary>Structured outcome code. Defaults to <see cref="CoreReasonCode.Null"/>.</summary>
         public CoreReasonCode ReasonCode { get; set; } = CoreReasonCode.Null;
-
+        /// <summary>Informational or error messages produced during execution.</summary>
         public string[] Messages { get; set; } = Array.Empty<string>();
+        /// <summary><see langword="true"/> when the service is a long-running parent.</summary>
         public bool IsLongRunning { get; set; }
+        /// <summary><see langword="true"/> when the service is a child spawned by a long-running parent.</summary>
         public bool IsLongRunningChild { get; set; }
     }
 

--- a/BaseLib.Core/Security/EncryptionKeyProvider.cs
+++ b/BaseLib.Core/Security/EncryptionKeyProvider.cs
@@ -2,15 +2,23 @@ using System.Security.Cryptography;
 
 namespace BaseLib.Core.Security
 {
+    /// <summary>
+    /// Simple local <see cref="IEncryptionKeyProvider"/> that generates random AES-256 data keys
+    /// using a caller-supplied master key. Intended for local development and testing only.
+    /// For production use, replace with <c>KmsEncryptionKeyProvider</c> from <c>BaseLib.Core.AmazonCloud</c>.
+    /// </summary>
     public class EncryptionKeyProvider : IEncryptionKeyProvider
     {
         private readonly byte[] masterKey;
 
+        /// <summary>Initializes the provider with a master key used to wrap/unwrap data keys.</summary>
+        /// <param name="masterKey">32-byte master key. Keep this secret.</param>
         public EncryptionKeyProvider(byte[] masterKey)
         {
             this.masterKey = masterKey;
         }
 
+        /// <inheritdoc/>
         public Task<(byte[] key, byte[] wrappedKey)> GetEncryptionKeyAsync()
         {
             var dataKey = RandomNumberGenerator.GetBytes(32);
@@ -24,6 +32,7 @@ namespace BaseLib.Core.Security
             return dataKey;
         }
 
+        /// <inheritdoc/>
         public Task<byte[]> UnwrapKeyAsync(byte[] wrappedKey)
         {
             var dataKey = UnwrapKey(wrappedKey);

--- a/BaseLib.Core/Serialization/CoreJsonSerializer.cs
+++ b/BaseLib.Core/Serialization/CoreJsonSerializer.cs
@@ -3,10 +3,16 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Serialization
 {
+    /// <summary>
+    /// <see cref="ICoreSerializer"/> implementation backed by <c>System.Text.Json</c>.
+    /// Pre-registers <see cref="PolymorphicConverter{T}"/> for <see cref="CoreRequestBase"/>
+    /// and <see cref="CoreResponseBase"/> so polymorphic payloads round-trip correctly.
+    /// </summary>
     public class CoreJsonSerializer : ICoreSerializer
     {
         private readonly JsonSerializerOptions options;
 
+        /// <summary>Initializes a new instance with polymorphic converters pre-registered.</summary>
         public CoreJsonSerializer()
         {
             this.options = new JsonSerializerOptions();
@@ -14,11 +20,13 @@ namespace BaseLib.Core.Serialization
             this.options.Converters.Add(new PolymorphicConverter<CoreResponseBase>());
         }
 
+        /// <inheritdoc/>
         public string Serialize<T>(T value)
         {
             return JsonSerializer.Serialize(value, options);
         }
 
+        /// <inheritdoc/>
         public T? Deserialize<T>(string json)
         {
             return JsonSerializer.Deserialize<T>(json, options);

--- a/BaseLib.Core/Serialization/CoreSecretAttribute.cs
+++ b/BaseLib.Core/Serialization/CoreSecretAttribute.cs
@@ -1,8 +1,13 @@
 namespace BaseLib.Core.Serialization
 {
+    /// <summary>
+    /// Marks a request or response property as sensitive. When serialized with
+    /// <c>CoreSecureJsonSerializer</c> or <c>SecurePolymorphicConverter</c>, the property value
+    /// is encrypted using AES-256 with a key managed by <see cref="Security.IEncryptionKeyProvider"/>.
+    /// Apply to fields such as passwords, tokens, or PII.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public class CoreSecretAttribute : Attribute
     {
-
     }
 }

--- a/BaseLib.Core/Serialization/CoreSecureJsonSerializer.cs
+++ b/BaseLib.Core/Serialization/CoreSecureJsonSerializer.cs
@@ -4,10 +4,18 @@ using BaseLib.Core.Security;
 
 namespace BaseLib.Core.Serialization
 {
+    /// <summary>
+    /// <see cref="ICoreSerializer"/> implementation that encrypts properties annotated with
+    /// <see cref="CoreSecretAttribute"/> using AES-256 envelope encryption.
+    /// Pre-registers <see cref="SecurePolymorphicConverter{T}"/> for <see cref="CoreRequestBase"/>
+    /// and <see cref="CoreResponseBase"/>.
+    /// </summary>
     public class CoreSecureJsonSerializer : ICoreSerializer
     {
         private readonly JsonSerializerOptions options;
 
+        /// <summary>Initializes the serializer with an encryption key provider.</summary>
+        /// <param name="keyProvider">Provider used to generate and unwrap AES-256 data keys.</param>
         public CoreSecureJsonSerializer(IEncryptionKeyProvider keyProvider)
         {
             this.options = new JsonSerializerOptions();
@@ -15,11 +23,13 @@ namespace BaseLib.Core.Serialization
             this.options.Converters.Add(new SecurePolymorphicConverter<CoreResponseBase>(keyProvider));
         }
 
+        /// <inheritdoc/>
         public string Serialize<T>(T value)
         {
             return JsonSerializer.Serialize(value, options);
         }
 
+        /// <inheritdoc/>
         public T? Deserialize<T>(string json)
         {
             return JsonSerializer.Deserialize<T>(json, options);

--- a/BaseLib.Core/Serialization/CoreSerializer.cs
+++ b/BaseLib.Core/Serialization/CoreSerializer.cs
@@ -7,17 +7,26 @@ namespace BaseLib.Core.Serialization
     {
         static ICoreSerializer? serializer;
 
+        /// <summary>
+        /// Registers the <see cref="ICoreSerializer"/> instance used by all subsequent
+        /// <see cref="Serialize{T}"/> and <see cref="Deserialize{T}"/> calls.
+        /// Must be called once at application startup before any service runs.
+        /// </summary>
         public static void Initialize(ICoreSerializer s)
         {
             serializer = s;
         }
 
+        /// <summary>Serializes <paramref name="value"/> to JSON using the registered serializer.</summary>
+        /// <typeparam name="T">The type to serialize.</typeparam>
         public static string Serialize<T>(T value)
         {
             if (serializer == null) throw new NullReferenceException("Serializer not present, invoke static Initialize(ICoreSerializer)");
             return serializer.Serialize(value);
         }
 
+        /// <summary>Deserializes a JSON string to <typeparamref name="T"/> using the registered serializer.</summary>
+        /// <typeparam name="T">The target type.</typeparam>
         public static T? Deserialize<T>(string json)
         {
             if (serializer == null) throw new NullReferenceException("Serializer not present, invoke static Initialize(ICoreSerializer)");

--- a/BaseLib.Core/Serialization/FlattenCoreReasonCodeConverter.cs
+++ b/BaseLib.Core/Serialization/FlattenCoreReasonCodeConverter.cs
@@ -9,17 +9,20 @@ namespace BaseLib.Core.Serialization
     /// </summary>
     public class FlattenCoreReasonCodeConverter : JsonConverter<CoreResponseBase>
     {
+        /// <inheritdoc/>
         public override bool CanConvert(Type typeToConvert)
         {
             var canConvert = typeof(CoreResponseBase).IsAssignableFrom(typeToConvert);
             return canConvert;
         }
 
+        /// <inheritdoc/>
         public override CoreResponseBase? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, CoreResponseBase value, JsonSerializerOptions options)
         {
             var type = value.GetType();

--- a/BaseLib.Core/Serialization/PolymorphicConverter.cs
+++ b/BaseLib.Core/Serialization/PolymorphicConverter.cs
@@ -13,11 +13,13 @@ namespace BaseLib.Core.Serialization
         where T : class
     {
         
+        /// <inheritdoc/>
         public override bool CanConvert(Type typeToConvert)
         {
             return typeof(T).IsAssignableFrom(typeToConvert);
         }
 
+        /// <inheritdoc/>
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             //check start of the object
@@ -65,6 +67,7 @@ namespace BaseLib.Core.Serialization
 
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             var type = value.GetType();

--- a/BaseLib.Core/Serialization/SecurePolymorphicConverter.cs
+++ b/BaseLib.Core/Serialization/SecurePolymorphicConverter.cs
@@ -21,11 +21,13 @@ namespace BaseLib.Core.Serialization
             this.keyProvider = keyProvider;
         }
 
+        /// <inheritdoc/>
         public override bool CanConvert(Type typeToConvert)
         {
             return typeof(T).IsAssignableFrom(typeToConvert);
         }
 
+        /// <inheritdoc/>
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             //check start of the object
@@ -101,6 +103,7 @@ namespace BaseLib.Core.Serialization
 
         }
 
+        /// <inheritdoc/>
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
             var type = value.GetType();

--- a/BaseLib.Core/Serialization/SecurePolymorphicConverter.cs
+++ b/BaseLib.Core/Serialization/SecurePolymorphicConverter.cs
@@ -14,6 +14,8 @@ namespace BaseLib.Core.Serialization
     {
         private readonly IEncryptionKeyProvider keyProvider;
         
+        /// <summary>Initializes the converter with the key provider used to encrypt/decrypt secret properties.</summary>
+        /// <param name="keyProvider">Provider used to generate and unwrap AES-256 data keys.</param>
         public SecurePolymorphicConverter(IEncryptionKeyProvider keyProvider)
         {
             this.keyProvider = keyProvider;

--- a/BaseLib.Core/Services/CoreLongRunningServiceBase.cs
+++ b/BaseLib.Core/Services/CoreLongRunningServiceBase.cs
@@ -4,6 +4,15 @@ using FluentValidation;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Base class for long-running (suspendable/resumable) services. Extends
+    /// <see cref="CoreServiceBase{TRequest,TResponse}"/> with the ability to fire child services
+    /// asynchronously, suspend execution while children run, and resume once all children finish.
+    /// Implement <see cref="CoreServiceBase{TRequest,TResponse}.RunAsync()"/> to start the workflow
+    /// and <see cref="ResumeAsync()"/> to finalise it after children complete.
+    /// </summary>
+    /// <typeparam name="TRequest">The strongly-typed request object for this service.</typeparam>
+    /// <typeparam name="TResponse">The strongly-typed response object for this service.</typeparam>
     public abstract partial class CoreLongRunningServiceBase<TRequest, TResponse> : CoreServiceBase<TRequest, TResponse>, ICoreLongRunningService<TResponse>
         where TRequest : CoreRequestBase
         where TResponse : CoreResponseBase, new()
@@ -12,6 +21,11 @@ namespace BaseLib.Core.Services
         private readonly ICoreServiceStateStore stateStore;
         private int childrenCount = 0; // This will be accessed with Interlocked methods for thread safety
 
+        /// <summary>Initializes the long-running service base with its required dependencies.</summary>
+        /// <param name="invoker">Fire-only dispatcher used to enqueue child service executions.</param>
+        /// <param name="stateStore">Store used to persist and restore service state across suspension/resume cycles.</param>
+        /// <param name="validator">Optional FluentValidation validator for the request.</param>
+        /// <param name="eventSink">Optional status-event sink. Defaults to <see cref="NullCoreEventSink"/>.</param>
         public CoreLongRunningServiceBase(ICoreServiceFireOnly invoker, ICoreServiceStateStore stateStore, IValidator<TRequest>? validator = null, ICoreStatusEventSink? eventSink = null)
             : base(validator, eventSink)
         {
@@ -41,6 +55,7 @@ namespace BaseLib.Core.Services
             await this.OnWriteStatusEventAsync();
         }
 
+        /// <inheritdoc/>
         protected override CoreStatusEvent GetStatusEvent()
         {
             var statusEvent = base.GetStatusEvent();
@@ -104,8 +119,17 @@ namespace BaseLib.Core.Services
 
         }
 
+        /// <summary>Contains the resumption logic executed after all child services have completed. Implemented by derived classes.</summary>
+        /// <returns>The final response produced when the long-running workflow completes.</returns>
         protected abstract Task<TResponse> ResumeAsync();
 
+        /// <summary>
+        /// Enqueues a single child service for asynchronous execution and increments the internal children counter.
+        /// The parent service will be resumed once all enqueued children finish.
+        /// </summary>
+        /// <typeparam name="TService">Type of the child service to fire.</typeparam>
+        /// <param name="request">Request payload for the child service.</param>
+        /// <param name="correlationId">Correlation ID to pass to the child. Defaults to this service's <see cref="CoreServiceBase{TRequest,TResponse}.OperationId"/>.</param>
         public virtual Task FireAsync<TService>(CoreRequestBase request, string? correlationId = null)
             where TService : ICoreServiceBase
         {
@@ -114,6 +138,13 @@ namespace BaseLib.Core.Services
             return this.fireOnly.FireAsync<TService>(request, correlationId ?? this.OperationId, isLongRunningChild: true);
         }
 
+        /// <summary>
+        /// Enqueues multiple child services for asynchronous batch execution and increments the internal children counter by the batch size.
+        /// The parent service will be resumed once all enqueued children finish.
+        /// </summary>
+        /// <typeparam name="TService">Type of the child service to fire.</typeparam>
+        /// <param name="requests">Collection of request payloads, one per child service invocation.</param>
+        /// <param name="correlationId">Correlation ID to pass to the children. Defaults to this service's <see cref="CoreServiceBase{TRequest,TResponse}.OperationId"/>.</param>
         public virtual Task FireManyAsync<TService>(IEnumerable<CoreRequestBase> requests, string? correlationId = null)
             where TService : ICoreServiceBase
         {
@@ -123,6 +154,12 @@ namespace BaseLib.Core.Services
             return this.fireOnly.FireManyAsync<TService>(requests, correlationId ?? this.OperationId, isLongRunningChild: true);
         }
 
+        /// <summary>
+        /// Captures the full instance-field graph of this service (including inherited private fields)
+        /// as a dictionary suitable for passing to <see cref="ICoreServiceStateStore.WriteAsync"/>.
+        /// Read-only and compiler-generated backing fields are excluded.
+        /// </summary>
+        /// <returns>Dictionary mapping field names to their current values.</returns>
         protected IDictionary<string, object?> GetState()
         {
             var dict = new Dictionary<string, object?>();
@@ -146,6 +183,11 @@ namespace BaseLib.Core.Services
             return dict;
         }
 
+        /// <summary>
+        /// Restores the instance-field graph from a previously captured state dictionary,
+        /// reconstructing the service to the same in-memory state it had when it was suspended.
+        /// </summary>
+        /// <param name="state">Dictionary produced by <see cref="GetState"/>.</param>
         protected void SetState(IDictionary<string, object?> state)
         {
             var type = this.GetType();

--- a/BaseLib.Core/Services/CoreServiceBase.cs
+++ b/BaseLib.Core/Services/CoreServiceBase.cs
@@ -3,6 +3,13 @@ using FluentValidation;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Base class for all Core services. Handles the request/response lifecycle, optional
+    /// FluentValidation, status-event emission, and structured error handling.
+    /// Derive from this class and implement <see cref="RunAsync()"/> with the business logic.
+    /// </summary>
+    /// <typeparam name="TRequest">The strongly-typed request object for this service.</typeparam>
+    /// <typeparam name="TResponse">The strongly-typed response object for this service.</typeparam>
     public abstract partial class CoreServiceBase<TRequest, TResponse> : ICoreServiceBase<TRequest, TResponse>
          where TRequest : CoreRequestBase
          where TResponse : CoreResponseBase, new()
@@ -13,6 +20,7 @@ namespace BaseLib.Core.Services
         private DateTimeOffset startedOn;
         private DateTimeOffset finishedOn;
         private CoreServiceStatus status;
+        /// <summary>Gets or sets the current execution status of this service instance.</summary>
         protected CoreServiceStatus Status
         {
             get { return this.status; }
@@ -20,40 +28,60 @@ namespace BaseLib.Core.Services
         }
 
         private TRequest? request;
+        /// <summary>Gets the current request. Throws <see cref="NullReferenceException"/> if accessed before <see cref="RunAsync(TRequest,string?,bool)"/> is called.</summary>
         protected TRequest Request
         {
             get { return this.request ?? throw new NullReferenceException("Request is null"); }
         }
 
         private TResponse? response;
+        /// <summary>Gets or sets the response being built by this service execution.</summary>
         protected TResponse? Response
         {
             get { return this.response; }
             set { this.response = value; }
         }
 
+        /// <summary>Optional FluentValidation validator applied before <see cref="RunAsync()"/> is called.</summary>
         protected IValidator<TRequest>? Validator { get; set; }
+        /// <summary>Sink that receives <see cref="CoreStatusEvent"/> notifications at service start and finish.</summary>
         protected ICoreStatusEventSink EventSink { get; }
 
+        /// <summary>Unique identifier for this service execution, assigned at the start of each run.</summary>
         protected string? OperationId { get { return this.operationId; } }
+        /// <summary>Correlation identifier passed in from the caller, used to group related operations.</summary>
         protected string? CorrelationId { get { return this.correlationId; } }
 
+        /// <summary>UTC timestamp captured when this service execution began.</summary>
         protected DateTimeOffset StartedOn { get { return this.startedOn; } }
 
+        /// <summary>Gets or sets the UTC timestamp captured when this service execution finished.</summary>
         protected DateTimeOffset FinishedOn { get { return this.finishedOn; } set { this.finishedOn = value; } }
 
+        /// <summary>Initializes the service with optional validation and event-sink dependencies.</summary>
+        /// <param name="validator">FluentValidation validator for the request. Pass <see langword="null"/> to skip validation.</param>
+        /// <param name="eventSink">Status-event sink. Defaults to <see cref="NullCoreEventSink"/> when <see langword="null"/>.</param>
         public CoreServiceBase(IValidator<TRequest>? validator = null, ICoreStatusEventSink? eventSink = null)
         {
             this.Validator = validator;
             this.EventSink = eventSink ?? new NullCoreEventSink();
         }
 
+        /// <inheritdoc/>
         public async virtual Task<CoreResponseBase> RunAsync(CoreRequestBase request, string? correlationId = null, bool isLongRunningChild = false)
         {
             var response = await RunAsync((TRequest)request, correlationId, isLongRunningChild);
             return response;
         }
 
+        /// <summary>
+        /// Executes the service with a strongly-typed request. Validates the request (if a validator
+        /// is configured), calls <see cref="RunAsync()"/>, emits status events, and handles exceptions.
+        /// </summary>
+        /// <param name="request">The typed request to process.</param>
+        /// <param name="correlationId">Optional correlation ID to link related operations.</param>
+        /// <param name="isLongRunningChild">Set to <see langword="true"/> when this service is a child of a long-running parent.</param>
+        /// <returns>The typed response produced by <see cref="RunAsync()"/>.</returns>
         public async virtual Task<TResponse> RunAsync(TRequest request, string? correlationId = null, bool isLongRunningChild = false)
         {
             try
@@ -116,6 +144,11 @@ namespace BaseLib.Core.Services
 
         }
 
+        /// <summary>
+        /// Called after <see cref="RunAsync()"/> completes (or throws). Sets the status to
+        /// <see cref="CoreServiceStatus.Finished"/> and emits the final status event.
+        /// Override in long-running services to suspend instead of finishing.
+        /// </summary>
         protected virtual Task FinalizeAsync()
         {
             this.status = CoreServiceStatus.Finished;
@@ -125,13 +158,23 @@ namespace BaseLib.Core.Services
             return this.OnWriteStatusEventAsync();
         }
 
+        /// <summary>Contains the business logic for this service. Implemented by derived classes.</summary>
+        /// <returns>The response produced by this service.</returns>
         protected abstract Task<TResponse> RunAsync();
 
+        /// <summary>
+        /// Builds a <see cref="CoreStatusEvent"/> and writes it to <see cref="EventSink"/>.
+        /// Override to add custom logic before or after the event is emitted.
+        /// </summary>
         protected virtual async Task OnWriteStatusEventAsync()
         {
             await this.EventSink.WriteAsync(this.GetStatusEvent());
         }
 
+        /// <summary>Creates a failed response with the given reason code and optional messages.</summary>
+        /// <param name="reasonCode">Domain enum value describing why the operation failed.</param>
+        /// <param name="messages">Optional diagnostic messages to include in the response.</param>
+        /// <returns>A new <typeparamref name="TResponse"/> with <c>Succeeded = false</c>.</returns>
         public TResponse Fail(Enum reasonCode, params string[] messages)
         {
             return new TResponse
@@ -142,6 +185,10 @@ namespace BaseLib.Core.Services
             };
         }
 
+        /// <summary>Creates a successful response, optionally overriding the default reason code.</summary>
+        /// <param name="reasonCode">Reason code to use. Defaults to <see cref="CoreServiceReasonCode.Succeeded"/> when <see langword="null"/>.</param>
+        /// <param name="messages">Optional informational messages to include in the response.</param>
+        /// <returns>A new <typeparamref name="TResponse"/> with <c>Succeeded = true</c>.</returns>
         public TResponse Succeed(Enum? reasonCode = null, params string[] messages)
         {
             return new TResponse
@@ -151,6 +198,8 @@ namespace BaseLib.Core.Services
             };
         }
 
+        /// <summary>Builds the <see cref="CoreStatusEvent"/> that describes the current execution state.</summary>
+        /// <returns>A populated <see cref="CoreStatusEvent"/> ready to be written to <see cref="EventSink"/>.</returns>
         protected virtual CoreStatusEvent GetStatusEvent()
         {
             //type of the service

--- a/BaseLib.Core/Services/CoreServiceReasonCode.cs
+++ b/BaseLib.Core/Services/CoreServiceReasonCode.cs
@@ -3,7 +3,7 @@
 namespace BaseLib.Core.Services
 {
     /// <summary>
-    /// Built-in reason codes set by the framework on <see cref="CoreResponseBase.ReasonCode"/>
+    /// Built-in reason codes set by the framework on <c>CoreResponseBase.ReasonCode</c>
     /// when a service completes. Domain-specific enums can be used alongside these values.
     /// Declared as <see cref="FlagsAttribute"/> so that <c>Suspended</c> can be OR-ed with other codes.
     /// </summary>

--- a/BaseLib.Core/Services/CoreServiceReasonCode.cs
+++ b/BaseLib.Core/Services/CoreServiceReasonCode.cs
@@ -10,27 +10,35 @@ namespace BaseLib.Core.Services
     [Flags]
     public enum CoreServiceReasonCode
     {
+        /// <summary>Default/unset state. No operation has been performed yet.</summary>
         [Description("Undefined")]
         Undefined = 0,
 
+        /// <summary>The operation completed successfully.</summary>
         [Description("Operación exitosa")]
         Succeeded = 1,
 
+        /// <summary>The operation failed.</summary>
         [Description("Error Operacion")]
         Failed = 2,
 
+        /// <summary>The operation was suspended and is awaiting child completions before resuming.</summary>
         [Description("Suspendida")]
         Suspended = 4,
 
+        /// <summary>The requested operation has not been implemented.</summary>
         [Description("Operación no implementada")]
         NotImplemented = 64,
 
+        /// <summary>The service is temporarily unavailable due to maintenance.</summary>
         [Description("Operación en mantenimiento")]
         Maintenance = 65,
 
+        /// <summary>The request failed FluentValidation checks before the service logic ran.</summary>
         [Description("Resultado de validación de request no es es válido")]
         ValidationResultNotValid = 96,
 
+        /// <summary>An unhandled exception occurred during service execution.</summary>
         [Description("Ocurrio una excepción en el sistema")]
         ExceptionHappened = 127
     }

--- a/BaseLib.Core/Services/CoreServiceReasonCode.cs
+++ b/BaseLib.Core/Services/CoreServiceReasonCode.cs
@@ -2,6 +2,11 @@
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Built-in reason codes set by the framework on <see cref="CoreResponseBase.ReasonCode"/>
+    /// when a service completes. Domain-specific enums can be used alongside these values.
+    /// Declared as <see cref="FlagsAttribute"/> so that <c>Suspended</c> can be OR-ed with other codes.
+    /// </summary>
     [Flags]
     public enum CoreServiceReasonCode
     {

--- a/BaseLib.Core/Services/CoreServiceRunner.cs
+++ b/BaseLib.Core/Services/CoreServiceRunner.cs
@@ -3,16 +3,24 @@ using System.Collections.Concurrent;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// Resolves and executes services by assembly-qualified type name using the DI container.
+    /// Resolved types are cached for performance on subsequent calls.
+    /// Register as a singleton in your DI container.
+    /// </summary>
     public class CoreServiceRunner : ICoreServiceRunner
     {
         private readonly ConcurrentDictionary<string, Type> _typeCache = new();
         private readonly IServiceProvider serviceProvider;
 
+        /// <summary>Initializes the runner with the application service provider.</summary>
+        /// <param name="serviceProvider">The DI container used to resolve service instances.</param>
         public CoreServiceRunner(IServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
         }
 
+        /// <inheritdoc/>
         public Task<CoreResponseBase> RunAsync(string typeName, CoreRequestBase request, string? correlationId = null, bool IsLongRunningChild = false)
         {
             var service = this.ResolveServiceByTypeName(typeName) as ICoreServiceBase
@@ -20,6 +28,7 @@ namespace BaseLib.Core.Services
             return service.RunAsync(request, correlationId, IsLongRunningChild);
         }
 
+        /// <inheritdoc/>
         public Task<CoreResponseBase> ResumeAsync(string typeName, string operationId)
         {
             var service = this.ResolveServiceByTypeName(typeName) as ICoreLongRunningService

--- a/BaseLib.Core/Services/CoreServiceState.cs
+++ b/BaseLib.Core/Services/CoreServiceState.cs
@@ -2,32 +2,48 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
-    public class CoreServiceState 
+    /// <summary>
+    /// Typed view over the field-level state dictionary persisted by
+    /// <see cref="ICoreServiceStateStore"/> for long-running services.
+    /// Provides strongly-typed accessors for the common framework fields and
+    /// generic <see cref="Get{T}"/> / <see cref="Set{T}"/> helpers for custom fields.
+    /// </summary>
+    public class CoreServiceState
     {
         private readonly IDictionary<string, object> environment;
 
+        /// <summary>Creates a state view over an optional pre-populated dictionary.</summary>
+        /// <param name="environment">Existing state dictionary, or <see langword="null"/> to start empty.</param>
         public CoreServiceState(IDictionary<string, object>? environment = null)
         {
             this.environment = environment ?? new Dictionary<string, object>(StringComparer.Ordinal);
         }
 
+        /// <summary>UTC timestamp when the service started.</summary>
         public DateTimeOffset StartedOn => this.Get<DateTimeOffset>("StartedOn");
-       
+        /// <summary>UTC timestamp when the service finished or was suspended.</summary>
         public DateTimeOffset FinishedOn => this.Get<DateTimeOffset>("FinishedOn");
-
+        /// <summary>Unique operation identifier.</summary>
         public string? OperationId => this.Get<string?>("OperationId");
-
+        /// <summary>Correlation identifier linking related operations.</summary>
         public string? CorrelationId => this.Get<string?>("CorrelationId");
-
+        /// <summary>The original request payload.</summary>
         public CoreRequestBase? Request => this.Get<CoreRequestBase?>("Request");
-
+        /// <summary>The response produced so far, or <see langword="null"/> if not yet set.</summary>
         public CoreResponseBase? Response => this.Get<CoreResponseBase?>("Response");
 
+        /// <summary>Retrieves a typed value from the state dictionary by key.</summary>
+        /// <typeparam name="T">The expected value type.</typeparam>
+        /// <param name="key">The state dictionary key.</param>
         public virtual T? Get<T>(string key)
         {
             return environment.TryGetValue(key, out var value) ? (T)value : default;
         }
         
+        /// <summary>Stores a value in the state dictionary under the given key.</summary>
+        /// <typeparam name="T">The value type.</typeparam>
+        /// <param name="key">The state dictionary key.</param>
+        /// <param name="value">The value to store. <see langword="null"/> values are ignored.</param>
         public virtual void Set<T>(string key, T value)
         {
             if (value == null) { return; }

--- a/BaseLib.Core/Services/JournalEventHandler.cs
+++ b/BaseLib.Core/Services/JournalEventHandler.cs
@@ -18,6 +18,7 @@ namespace BaseLib.Core.Services
             this.eventStore = eventStore;
         }
 
+        /// <inheritdoc/>
         public async Task<int> HandleAsync(CoreStatusEvent statusEvent)
         {
             if (statusEvent.Status == CoreServiceStatus.Finished)

--- a/BaseLib.Core/Services/JournalEventHandler.cs
+++ b/BaseLib.Core/Services/JournalEventHandler.cs
@@ -10,6 +10,8 @@ namespace BaseLib.Core.Services
         private readonly IJournalEntryWriter journalWriter;
         private readonly ICoreStatusEventStore eventStore;
 
+        /// <param name="journalWriter">Writer that persists journal entries to the relational store.</param>
+        /// <param name="eventStore">Store that persists the full event payload for auditing.</param>
         public JournalEventHandler(IJournalEntryWriter journalWriter, ICoreStatusEventStore eventStore)
         {
             this.journalWriter = journalWriter;

--- a/BaseLib.Core/Services/NullCoreEventSink.cs
+++ b/BaseLib.Core/Services/NullCoreEventSink.cs
@@ -2,8 +2,13 @@ using BaseLib.Core.Models;
 
 namespace BaseLib.Core.Services
 {
+    /// <summary>
+    /// No-op implementation of <see cref="ICoreStatusEventSink"/> used as the default when no
+    /// event sink is injected. Silently discards all events.
+    /// </summary>
     public class NullCoreEventSink : ICoreStatusEventSink
     {
+        /// <inheritdoc/>
         public Task WriteAsync(CoreStatusEvent statusEvent)
         {
              return Task.CompletedTask;


### PR DESCRIPTION
## Summary

- Adds XML doc comments to all publicly visible members across `BaseLib.Core`, `BaseLib.Core.AmazonCloud`, and `BaseLib.Core.MySql`
- Covers concrete classes: `CoreServiceBase`, `CoreLongRunningServiceBase`, `CoreReasonCode`, `CoreServiceReasonCode`, serialization converters, extension methods, and all AmazonCloud/MySql implementations
- Fixes CS1574 unresolved cref warning in `CoreServiceReasonCode`
- Achieves **zero CS1591 and zero CS1574 warnings** on `dotnet build`

## Test plan

- [ ] `dotnet build` completes with 0 errors and 0 documentation warnings
- [ ] Review XML docs on key types: `CoreServiceBase<TRequest,TResponse>`, `CoreLongRunningServiceBase<TRequest,TResponse>`, `CoreReasonCode`, `SqsCoreServiceFireOnly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)